### PR TITLE
fix: don't return a rejected Promise  from getInitialProps 

### DIFF
--- a/targets/frontend/src/lib/auth/token.js
+++ b/targets/frontend/src/lib/auth/token.js
@@ -69,7 +69,6 @@ export async function auth(ctx) {
       // if we are on the client
       Router.push("/login");
     }
-    return Promise.reject(error);
   }
 }
 


### PR DESCRIPTION
to avoid sentry log that errors (quite common if trying to access "/" without being authentified before