### PR TITLE
feat(ingester): populate document table with @socialgouv/data-*

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ include:
   - /targets/alert-cli/.gitlab-ci.yml
   - /targets/hasura/.gitlab-ci.yml
   - /targets/frontend/.gitlab-ci.yml
+  - /targets/ingester/.gitlab-ci.yml
 
 workflow:
   rules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,15 @@ services:
     env_file:
       - .env
 
+  ingester:
+    build:
+      context: .
+      dockerfile: targets/ingester/Dockerfile
+      shm_size: 1.5g
+    depends_on:
+      - hasura
+    env_file:
+      - .env
+
 volumes:
   db_data:

--- a/targets/ingester/.eslintrc.json
+++ b/targets/ingester/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["@socialgouv/eslint-config-recommended"],
+  "settings": {
+    "jest": {
+      "version": 26
+    }
+  }
+}

--- a/targets/ingester/.gitlab-ci.yml
+++ b/targets/ingester/.gitlab-ci.yml
@@ -30,7 +30,7 @@ Register ingester:
   variables:
     CONTEXT: .
     DOCKER_BUILD_ARGS: >-
-      --shm-size 512M
+      --shm-size 1024M
       -f ./targets/ingester/Dockerfile
     IMAGE_NAME: $CI_REGISTRY_IMAGE/ingester
 

--- a/targets/ingester/.gitlab-ci.yml
+++ b/targets/ingester/.gitlab-ci.yml
@@ -30,7 +30,7 @@ Register ingester:
   variables:
     CONTEXT: .
     DOCKER_BUILD_ARGS: >-
-      --shm-size 1024M
+      --shm-size 1.2G
       -f ./targets/ingester/Dockerfile
     IMAGE_NAME: $CI_REGISTRY_IMAGE/ingester
 

--- a/targets/ingester/.gitlab-ci.yml
+++ b/targets/ingester/.gitlab-ci.yml
@@ -1,0 +1,119 @@
+Install ingester:
+  extends: .autodevops_install
+  image: node:14.7.0-alpine3.11
+  cache:
+    key:
+      files:
+        - yarn.lock
+      prefix: ${CI_JOB_NAME}
+    paths:
+      - yarn
+  script:
+    - yarn config set cache-folder $CI_PROJECT_DIR/yarn
+    - npx @socialgouv/yarn-workspace-focus-install --cwd targets/ingester
+  artifacts:
+    expire_in: 1 week
+    paths:
+      - targets/ingester/node_modules
+      - node_modules
+
+#
+#
+#
+
+Build ingester:
+  extends: .base_yarn_script
+  image: node:14.7.0-alpine3.11
+  needs:
+    - job: Install ingester
+      artifacts: true
+  before_script:
+    - cd targets/ingester
+  script:
+    - yarn build
+  artifacts:
+    expire_in: 1 week
+    paths:
+      - targets/ingester/dist
+
+#
+#
+#
+
+Register ingester:
+  extends: .autodevops_register_image
+  dependencies: null
+  needs:
+    - job: Build ingester
+      artifacts: true
+  variables:
+    CONTEXT: .
+    DOCKER_BUILD_ARGS: >-
+      --shm-size 512M
+      -f ./targets/ingester/Dockerfile
+    IMAGE_NAME: $CI_REGISTRY_IMAGE/ingester
+
+#
+#
+#
+
+.deploy_ingester_stage:
+  script:
+    - echo "kubectl config set-context --current --namespace=${K8S_NAMESPACE}"
+    - kubectl config set-context --current --namespace=${K8S_NAMESPACE}
+    - envsubst < targets/ingester/.k8s/ingester.cronjob.yaml | kubectl apply -f -
+
+Deploy ingester (dev):
+  extends:
+    - .autodevops_deploy_app_dev
+    - .deploy_ingester_stage
+  environment:
+    name: ${CI_COMMIT_REF_SLUG}-dev2
+
+Deploy ingester (prod):
+  extends:
+    - .autodevops_deploy_app_prod
+    - .deploy_ingester_stage
+  environment:
+    name: prod2
+  variables:
+    PRODUCTION: "true"
+
+#
+#
+#
+
+.trigger_ingester_cron:
+  when: manual
+  script:
+    - echo "kubectl config set-context --current --namespace=${K8S_NAMESPACE}"
+    - kubectl config set-context --current --namespace=${K8S_NAMESPACE}
+    - JOB_NAME="triggered-from-job-${CI_JOB_ID}-${RANDOM}"
+    - kubectl create job --from=cronjob/ingester "${JOB_NAME}"
+
+    - timeout 15m
+      bash -c "
+      until
+      kubectl get pod -l job-name=${JOB_NAME}
+      -o jsonpath='{.items[0].status.conditions[?(@.type==\"ContainersReady\")].status}' |
+      grep True
+      ; do sleep 1; done"
+
+    - kubectl logs -f job/${JOB_NAME}
+
+    - kubectl get jobs ${JOB_NAME} -o jsonpath='{.status.conditions}'
+    - kubectl get jobs ${JOB_NAME} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}'
+
+Trigger Ingester (dev):
+  extends:
+    - .autodevops_deploy_app_dev
+    - .trigger_ingester_cron
+  environment:
+    name: ${CI_COMMIT_REF_SLUG}-dev2
+
+Trigger Ingester (prod):
+  extends:
+    - .autodevops_deploy_app_prod
+    - .trigger_ingester_cron
+  environment:
+    name: prod2

--- a/targets/ingester/.gitlab-ci.yml
+++ b/targets/ingester/.gitlab-ci.yml
@@ -25,7 +25,7 @@ Register ingester:
   extends: .autodevops_register_image
   dependencies: null
   needs:
-    - job: Build ingester
+    - job: Install ingester
       artifacts: true
   variables:
     CONTEXT: .

--- a/targets/ingester/.gitlab-ci.yml
+++ b/targets/ingester/.gitlab-ci.yml
@@ -30,7 +30,7 @@ Register ingester:
   variables:
     CONTEXT: .
     DOCKER_BUILD_ARGS: >-
-      --shm-size 1.2G
+      --shm-size 1.5G
       -f ./targets/ingester/Dockerfile
     IMAGE_NAME: $CI_REGISTRY_IMAGE/ingester
 

--- a/targets/ingester/.gitlab-ci.yml
+++ b/targets/ingester/.gitlab-ci.yml
@@ -21,25 +21,6 @@ Install ingester:
 #
 #
 
-Build ingester:
-  extends: .base_yarn_script
-  image: node:14.7.0-alpine3.11
-  needs:
-    - job: Install ingester
-      artifacts: true
-  before_script:
-    - cd targets/ingester
-  script:
-    - yarn build
-  artifacts:
-    expire_in: 1 week
-    paths:
-      - targets/ingester/dist
-
-#
-#
-#
-
 Register ingester:
   extends: .autodevops_register_image
   dependencies: null

--- a/targets/ingester/.k8s/ingester.cronjob.yaml
+++ b/targets/ingester/.k8s/ingester.cronjob.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: ingester
+  labels:
+    app.kubernetes.io/part-of: ${CI_PROJECT_NAME}
+    owner: ${CI_PROJECT_NAME}
+    team: ${CI_PROJECT_NAME}
+spec:
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  schedule: "0 2 * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+            - name: update-ingester
+              image: ${CI_REGISTRY_IMAGE}/ingester:${IMAGE_TAG}
+              resources:
+                requests:
+                  cpu: 1500m
+                  memory: 2.5Gi
+                limits:
+                  cpu: 2000m
+                  memory: 3Gi
+              workingDir: /app
+              env:
+                - name: PRODUCTION
+                  value: "${PRODUCTION}"
+                - name: GRAPHQL_ENDPOINT
+                  value: "http://hasura-cdtn-admin/v1/graphql"
+              envFrom:
+                - secretRef:
+                    name: cdtn-admin-secrets
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
+            supplementalGroups:
+              - 1000
+          restartPolicy: Never
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ingester
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/targets/ingester/@types/contribution-data.d.ts
+++ b/targets/ingester/@types/contribution-data.d.ts
@@ -1,0 +1,6 @@
+
+declare module "@socialgouv/contributions-data/data/contributions.json" {
+  import { Question } from "@socialgouv/contributions-data"
+  const data: Question[];
+  export default data
+}

--- a/targets/ingester/@types/fiches-vdd.d.ts
+++ b/targets/ingester/@types/fiches-vdd.d.ts
@@ -1,0 +1,10 @@
+declare module "@socialgouv/fiches-vdd" {
+  export type RawJson = {
+    name: string
+    text: string
+    type: string
+    attributes: { ID: string, URL: string }
+    children: RawJson[]
+  }
+  export function getFiche(type: string, id: string): RawJson
+}

--- a/targets/ingester/@types/unist-util-find.d.ts
+++ b/targets/ingester/@types/unist-util-find.d.ts
@@ -1,0 +1,5 @@
+declare module "unist-util-find" {
+  import { Node, Parent } from "unist";
+
+  export default function find(root: Parent, matcher: (node: Node) => Boolean): Parent
+}

--- a/targets/ingester/Dockerfile
+++ b/targets/ingester/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json yarn.lock /app/
 COPY shared/graphql-client/package.json /app/shared/graphql-client/
 COPY shared/id-generator/package.json /app/shared/id-generator/
 COPY targets/ingester/package.json /app/targets/ingester/
+COPY targets/ingester/src /app/targets/ingester/src
 
 RUN  npx @socialgouv/yarn-workspace-focus-install --cwd targets/ingester --production -- --cache-folder /dev/shm/yarn
 

--- a/targets/ingester/Dockerfile
+++ b/targets/ingester/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14.7.0-alpine3.11
+
+WORKDIR /app
+
+COPY package.json yarn.lock /app/
+COPY shared/graphql-client/package.json /app/shared/graphql-client/
+COPY targets/ingester/package.json /app/ingester/
+
+RUN  npx @socialgouv/yarn-workspace-focus-install --cwd targets/ingester --production -- --cache-folder /dev/shm/yarn
+
+RUN chown -R node:node /app
+USER node
+
+ENV NODE_ENV=production
+
+CMD ["yarn", "workspace", "ingester","start"]

--- a/targets/ingester/Dockerfile
+++ b/targets/ingester/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 
 COPY package.json yarn.lock /app/
 COPY shared/graphql-client/package.json /app/shared/graphql-client/
-COPY targets/ingester/package.json /app/ingester/
+COPY shared/id-generator/package.json /app/shared/id-generator/
+COPY targets/ingester/package.json /app/targets/ingester/
 
 RUN  npx @socialgouv/yarn-workspace-focus-install --cwd targets/ingester --production -- --cache-folder /dev/shm/yarn
 
@@ -13,4 +14,4 @@ USER node
 
 ENV NODE_ENV=production
 
-CMD ["yarn", "workspace", "ingester","start"]
+CMD ["yarn", "workspace", "ingester", "start"]

--- a/targets/ingester/README.md
+++ b/targets/ingester/README.md
@@ -1,0 +1,16 @@
+# Ingester aka Miam-miam
+
+This program will populate the drocuments table with documents from various datasources (mostly @socialgouv/data-\* packages).
+
+- each article from LEGITEXT000006072050 will be a document
+- each CCn from @socialgouv/kali-data will be a document with generic data and dedicated contributions answer
+- each Question from @socialgouv/contributions-data will be a document
+- a filtered dataset from fiche-vdd
+- a filtered dataset from travail-emploi
+
+## Usage
+
+```sh
+# Populate database provided using env var
+$ yarn workspace ingester start
+```

--- a/targets/ingester/package.json
+++ b/targets/ingester/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "ingester",
+  "version": "1.0.0",
+  "dependencies": {
+    "@shared/graphql-client": "1.0.0",
+    "@shared/id-generator": "^1.0.0",
+    "@socialgouv/cdtn-monolog": "^1.1.2",
+    "@socialgouv/cdtn-slugify": "^4.31.1",
+    "@socialgouv/cdtn-sources": "^4.31.1",
+    "@socialgouv/contributions-data": "^2.18.0",
+    "@socialgouv/datafiller-data": "^1.64.0",
+    "@socialgouv/fiches-travail-data": "^3.220.0",
+    "@socialgouv/fiches-vdd": "^1.172.0",
+    "@socialgouv/kali-data": "^1.115.0",
+    "@socialgouv/legi-data": "^1.40.0",
+    "esm": "^3.2.25",
+    "query-string": "^6.13.5",
+    "remark": "^12.0.1",
+    "remark-html": "^13.0.1",
+    "unist-util-find": "^1.0.1",
+    "unist-util-parents": "^1.0.3",
+    "unist-util-select": "^3.0.1",
+    "winston": "^3.3.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.11.6",
+    "@babel/preset-env": "^7.11.5",
+    "@socialgouv/eslint-config-recommended": "^1.30.0",
+    "@types/jest": "^26.0.14",
+    "@types/node": "^14.6.4",
+    "@types/unist": "^2.0.3",
+    "eslint": "^7.8.1",
+    "jest": "^26.4.2",
+    "lint-staged": "^10.3.0",
+    "typescript": "^4.0.3"
+  },
+  "license": "MIT",
+  "main": "src/index.js",
+  "private": true,
+  "scripts": {
+    "start": "GRAPHQL_ENDPOINT=http://localhost:8080/v1/graphql HASURA_GRAPHQL_ADMIN_SECRET=admin1 node -r esm src/index.js",
+    "lint": "eslint src/**/*.js",
+    "types": "tsc",
+    "test": "jest"
+  },
+  "jest": {
+    "clearMocks": true,
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "src/**/*.js",
+      "!**/node_modules/**"
+    ],
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "/node_modules/"
+    ]
+  },
+  "lint-staged": {
+    "*.{j,t}s": [
+      "eslint --fix",
+      "jest --bail --findRelatedTests"
+    ]
+  }
+}

--- a/targets/ingester/src/agreementPages.js
+++ b/targets/ingester/src/agreementPages.js
@@ -1,0 +1,160 @@
+import slugify from "@socialgouv/cdtn-slugify";
+import contributions from "@socialgouv/contributions-data/data/contributions.json";
+import agreementsBlocks from "@socialgouv/datafiller-data/data/agreements.json";
+import kaliData from "@socialgouv/kali-data/data/index.json";
+import remark from "remark";
+import html from "remark-html";
+import find from "unist-util-find";
+import parents from "unist-util-parents";
+
+const compiler = remark().use(html, { sanitize: true });
+const createSorter = (fn = (a) => a) => (a, b) => fn(a) - fn(b);
+
+const contributionsWithSlug = contributions.map((contrib) => {
+  const slug = slugify(contrib.title);
+  return {
+    ...contrib,
+    slug,
+  };
+});
+
+function getAgreementPages() {
+  return kaliData
+    .sort(createSorter(({ num }) => parseInt(num, 10)))
+    .map((agreement) => {
+      const agreementTree = require(`@socialgouv/kali-data/data/${agreement.id}.json`);
+      const blocksData = agreementsBlocks.find(
+        // cid = container-id not chronical-id
+        (data) => data.cid === agreement.id
+      );
+      return {
+        ...getCCNInfo(agreement),
+        answers: getContributionAnswers(agreement.num),
+        articlesByTheme:
+          blocksData && blocksData.groups
+            ? getArticleByBlock(blocksData.groups, agreementTree)
+            : [],
+        nbTextes: getNbText(agreementTree),
+      };
+    });
+}
+
+/**
+ * Get CCn geenral information
+ * @param {Object} agreement
+ */
+function getCCNInfo({
+  id,
+  num,
+  date_publi,
+  effectif,
+  mtime,
+  title,
+  shortTitle,
+  url,
+}) {
+  return {
+    date_publi,
+    effectif,
+    id,
+    mtime,
+    num,
+    shortTitle,
+    slug: slugify(`${num}-${shortTitle}`.substring(0, 80)),
+    text: `IDCC ${num}: ${title} ${shortTitle}`,
+    title,
+    url,
+  };
+}
+
+/**
+ * Get CCn detailed informations about articles and texts
+ */
+function getNbText(agreementTree) {
+  const texteDeBase = find(agreementTree, (node) =>
+    node.data.title.startsWith("Texte de base")
+  );
+  if (!texteDeBase) {
+    return;
+  }
+
+  return texteDeBase.children.length;
+}
+
+/**
+ * Return contribution answer for a given idcc
+ * param {agreementNum} string
+ */
+function getContributionAnswers(agreementNum) {
+  const transformRef = ({ title, url, category, agreement }) => {
+    return {
+      category: category,
+      title,
+      url: url || (agreement && agreement.url),
+    };
+  };
+  return contributionsWithSlug
+    .map(({ title, slug, index, answers }) => {
+      const [answer] = answers.conventions.filter(
+        ({ idcc }) => parseInt(idcc) === parseInt(agreementNum)
+      );
+      const unhandledRegexp = /La convention collective ne prévoit rien sur ce point/i;
+      if (answer && !unhandledRegexp.test(answer.markdown)) {
+        const rootTheme = null;
+
+        return {
+          answer: compiler.processSync(answer.markdown).contents,
+          index,
+          question: title.trim(),
+          references: answer.references.map(transformRef),
+          slug,
+          theme: rootTheme,
+        };
+      }
+    })
+    .sort(createSorter((a) => a.index))
+    .filter(Boolean);
+}
+
+/**
+ * @param {id:<String>, selection:<String[]>}
+ * @param {Object} agreementTree
+ */
+function getArticleByBlock(groups, agreementTree) {
+  const treeWithParents = parents(agreementTree);
+  return groups
+    .filter(({ selection }) => selection.length > 0)
+    .sort(createSorter((a) => a.id))
+    .map(({ id, selection }) => ({
+      articles: selection
+        .map((articleId) => {
+          const node = find(
+            treeWithParents,
+            (node) => node.data.id === articleId
+          );
+          if (!node) {
+            console.error(
+              `${articleId} not found in idcc ${agreementTree.data.num}`
+            );
+          }
+          return node
+            ? {
+                cid: node.data.cid,
+                id: node.data.id,
+                section: node.parent.data.title,
+                title: node.data.num || "non numéroté",
+              }
+            : null;
+        })
+        .filter(Boolean),
+      bloc: id,
+    }))
+    .filter(({ articles }) => articles.length > 0);
+}
+
+if (require.main === module) {
+  const data = getAgreementPages();
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export { getAgreementPages };

--- a/targets/ingester/src/fichesServicePublic/format.js
+++ b/targets/ingester/src/fichesServicePublic/format.js
@@ -1,0 +1,73 @@
+import { SOURCES } from "@socialgouv/cdtn-sources";
+
+import { parseReference } from "./parseReference";
+/**
+ *
+ * @param {import("@socialgouv/fiches-vdd").RawJson} element
+ * @param {string} name
+ */
+function getChild(element, name) {
+  return element.children.find((el) => el.name === name);
+}
+
+/**
+ * Beware, this one is recursive
+ * @param {import("@socialgouv/fiches-vdd").RawJson | undefined} element
+ * @returns {string}
+ */
+function getText(element) {
+  if (!element) {
+    return "";
+  }
+  if (element.type === "text" && element.text) {
+    return element.text.trim();
+  }
+  if (element.children) {
+    return element.children.map((child) => getText(child)).join(" ");
+  }
+  return "";
+}
+/**
+ *
+ * @param {import("@socialgouv/fiches-vdd").RawJson} fiche
+ * @returns {Omit<import("src").FicheServicePublic, "url"> | null }
+ */
+export function format(fiche) {
+  if (!(fiche.children[0].name === "Publication")) return null;
+
+  const publication = fiche.children[0];
+  const { ID: id } = publication.attributes;
+
+  // We filter out the elements we will never use nor display
+  publication.children = publication.children.filter(
+    (child) => child.name !== "OuSAdresser" && child.name !== "ServiceEnLigne"
+  );
+
+  const title = getText(getChild(publication, "dc:title"));
+  const description = getText(getChild(publication, "dc:description"));
+  const dateRaw = getText(getChild(publication, "dc:date"));
+  const [year, month, day] = dateRaw.split(" ")[1].split("-");
+  const date = `${day}/${month}/${year}`;
+
+  const intro = getText(getChild(publication, "Introduction"));
+  const texte = getText(getChild(publication, "Texte"));
+  const listeSituations = getText(getChild(publication, "ListeSituations"));
+  const text = intro + " " + texte + " " + listeSituations;
+
+  const references_juridiques = publication.children
+    .filter((el) => el.name === "Reference")
+    .map(parseReference)
+    .reduce((acc, val) => acc.concat(val), []) // flatten the array
+    .filter(Boolean);
+
+  return {
+    date,
+    description,
+    id,
+    raw: JSON.stringify(publication),
+    references_juridiques,
+    source: SOURCES.SHEET_SP,
+    text,
+    title,
+  };
+}

--- a/targets/ingester/src/fichesServicePublic/index.js
+++ b/targets/ingester/src/fichesServicePublic/index.js
@@ -1,0 +1,88 @@
+import slugify from "@socialgouv/cdtn-slugify";
+import contributions from "@socialgouv/contributions-data/data/contributions.json";
+import externals from "@socialgouv/datafiller-data/data/externals.json";
+import { getFiche } from "@socialgouv/fiches-vdd";
+
+import { format } from "./format";
+
+// Extract external content url from Content tag markdown
+/**
+ *
+ * @param {string} markdown
+ * @returns { string | null}
+ */
+function extractMdxContentUrl(markdown) {
+  if (!markdown) return null;
+  // Check Content tag exist on markdown
+  const [, href = ""] = markdown.match(/<Content.*?href="([^"]+)".*?>/) || [];
+  const matchUrl = href.match(
+    /\bhttps?:\/\/(www\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)/gi
+  );
+  return matchUrl ? matchUrl[0] : null;
+}
+
+const slugMap = {
+  associations: "associations",
+  particuliers: "particuliers",
+  "professionnels-entreprises": "professionnels",
+};
+
+const fichesIdFromContrib = /** @type {import("@socialgouv/contributions-data").Question[]}*/ (contributions)
+  .map(({ answers }) => extractMdxContentUrl(answers.generic.markdown))
+  .filter(Boolean)
+  .map((url) => {
+    const [, id] = /** @type {string} */ (url).match(/\/(\w+)$/);
+    return id;
+  });
+
+export function getFichesServicePublic() {
+  const vddExternals = externals.find(
+    ({ title }) => title === "service-public.fr"
+  );
+
+  if (!vddExternals || !vddExternals.urls.length) {
+    throw new Error("fiches sp urls not found");
+  }
+  const fiches = vddExternals.urls.flatMap((url) => {
+    const [, slugType, idFiche] =
+      url.match(/([a-z-]+)\/vosdroits\/(F[0-9]+)$/) || [];
+    if (!Object.prototype.hasOwnProperty.call(slugMap, slugType) || !idFiche) {
+      throw new Error(`Unknown fiche ${url}`);
+    }
+    let fiche;
+    try {
+      fiche = getFiche(
+        slugMap[/** @type { keyof slugMap } */ (slugType)],
+        idFiche
+      );
+    } catch (err) {
+      console.error(url);
+      return [];
+    }
+
+    const ficheSp = format(fiche);
+
+    if (!ficheSp) return [];
+
+    return [
+      {
+        ...ficheSp,
+        excludeFromSearch: fichesIdFromContrib.includes(ficheSp.id),
+        slug: slugify(ficheSp.title),
+      },
+    ];
+  });
+
+  fichesIdFromContrib.forEach((idFiche) => {
+    if (fiches.find(({ id }) => idFiche === id) === undefined) {
+      throw Error(
+        `[FICHE-SP] The ${idFiche} from service-public is embeded in a contribution and was not found`
+      );
+    }
+  });
+  return fiches;
+}
+
+if (module === require.main) {
+  console.log(JSON.stringify(getFichesServicePublic(), null, 2));
+}

--- a/targets/ingester/src/fichesServicePublic/parseReference.js
+++ b/targets/ingester/src/fichesServicePublic/parseReference.js
@@ -1,0 +1,103 @@
+// Do we really need this one ?
+import slugify from "@socialgouv/cdtn-slugify";
+import conventions from "@socialgouv/kali-data/data/index.json";
+import cdt from "@socialgouv/legi-data/data/LEGITEXT000006072050.json";
+import queryString from "query-string";
+import find from "unist-util-find";
+
+const isConventionCollective = (qs) => qs.idConvention;
+const isCodeDuTravail = (qs) => qs.cidTexte === "LEGITEXT000006072050";
+const isJournalOfficiel = (qs) => (qs.cidText || "").includes("JORFTEXT");
+
+const getTextType = (qs) => {
+  if (isCodeDuTravail(qs)) {
+    return "code-du-travail";
+  }
+  if (isConventionCollective(qs)) {
+    return "convention-collective";
+  }
+  if (isJournalOfficiel(qs)) {
+    return "journal-officiel";
+  }
+};
+
+// resolve article.num in LEGI extract
+const getArticleNumFromId = (id) => {
+  const article = find(
+    cdt,
+    (node) => node.type === "article" && node.data.id === id
+  );
+  return article && article.data.num;
+};
+
+const getArticlesFromSection = (id) => {
+  const section = find(cdt, (node) => node.data.id === id);
+  if (section) {
+    return section.children
+      .filter((child) => child.type === "article")
+      .map((article) => createCDTRef(article.data.num));
+  }
+  return [];
+};
+
+const createCDTRef = (id) => ({
+  id: id.toLowerCase(),
+  title: `Article ${id} du code du travail`,
+  type: "code-du-travail",
+});
+
+const createCCRef = (id, slug, title) => ({
+  id,
+  slug,
+  title,
+  type: "convention-collective",
+});
+
+const createJORef = (id, title, url) => ({
+  id,
+  title,
+  type: "journal-officiel",
+  url,
+});
+
+/**
+ *
+ * @param {import("@socialgouv/fiches-vdd").RawJson} reference
+ */
+export function parseReference(reference) {
+  const { URL: url } = reference.attributes;
+  const qs = queryString.parse(url.split("?")[1]);
+  const type = getTextType(qs);
+  switch (type) {
+    case "code-du-travail":
+      if (qs.idArticle) {
+        // resolve related article num from CDT structure
+        const articleNum = getArticleNumFromId(qs.idArticle);
+        if (!articleNum) return [];
+        return [createCDTRef(articleNum)];
+      }
+      if (qs.idSectionTA) {
+        // resolve related articles from CDT structure
+        return getArticlesFromSection(qs.idSectionTA);
+      }
+      break;
+    case "convention-collective": {
+      const {
+        id,
+        title,
+        num,
+        shortTitle,
+      } = /** @type {import("src").KaliContainer} */ (conventions).find(
+        (convention) => convention.id === qs.idConvention
+      );
+      const slug = slugify(`${num}-${shortTitle}`.substring(0, 80)); // as in populate.js
+      return [createCCRef(id, slug, title)];
+    }
+    case "journal-officiel":
+      return [
+        createJORef(qs.cidTexte, reference.children[0].children[0].text, url),
+      ];
+    default:
+      return [];
+  }
+}

--- a/targets/ingester/src/getSocialgouvVersions.js
+++ b/targets/ingester/src/getSocialgouvVersions.js
@@ -1,0 +1,10 @@
+const dependencies = require("../package.json").dependencies;
+
+export function getVersions(pattern = "^@socialgouv/") {
+  const packageRule = new RegExp(pattern);
+  return Object.entries(dependencies)
+    .filter(([name]) => {
+      return packageRule.test(name);
+    })
+    .reduce((state, [name, version]) => ({ ...state, [name]: version }), {});
+}

--- a/targets/ingester/src/index.d.ts
+++ b/targets/ingester/src/index.d.ts
@@ -1,0 +1,105 @@
+import type { SourceValues } from "@socialgouv/cdtn-sources"
+import type { Answer, Question } from "@socialgouv/contributions-data"
+
+export as namespace ingester
+
+type Document = {
+  id: string
+  description: string
+  title: string
+  source: SourceValues
+  text: string
+  slug: string
+}
+
+type ExternalDocument = Document & {
+  url: string
+}
+
+type KaliContainer = ExternalDocument & {
+  idcc: number
+  shortTitle: string
+}
+
+type LegiArticle = ExternalDocument & {
+  dateDebut: number
+  html: string
+}
+
+type FicheServicePublic = ExternalDocument & {
+  date: string //"O1/01/2021"
+  raw: string
+  references_juridiques: Reference[]
+}
+
+type EditorialDocument = Document & {
+  date: string
+  contents: EditorialContent[]
+}
+
+type Tool = Document & {
+  action: string
+  date: string //"O1/01/2021"
+  icon: string
+}
+
+type ExternalTool = ExternalDocument & {
+  action: string
+  icon: string
+}
+
+type DocTemplate = Document & {
+  author: string
+  date: string // "10/12/2019"
+  filename: string
+  filesize: number,
+  fileurl: string
+  html: string
+}
+
+type EditorialContent = {
+  type: "markdown" | "graphic"
+  name: string
+  title: string
+  references: Reference[]
+}
+
+type Contribution = Document & Question
+
+type ThematicFile = {
+  categories: ThematicFileCategory[]
+}
+
+type ThematicFileCategory = {
+  icon: string
+  id: string
+  position: number
+  ref: InternalReference[]
+}
+
+type FicheTravailEmploi = ExternalDocument & {
+  anchor: string
+}
+
+
+type Reference = UrlReference | CdtReference
+
+type UrlReference = {
+  title: string
+  url: string
+  type: "external"
+}
+
+type CdtReference = {
+  id: string
+  title: string
+  type: "code-du-travail"
+}
+
+/** Internal reference reperesent a content from cdtn */
+type InternalReference = {
+  title: string
+  url: string // cdtn content slug
+}
+
+type CdtnDocument = LegiArticle | KaliContainer | FicheServicePublic | FicheTravailEmploi | EditorialDocument

--- a/targets/ingester/src/index.js
+++ b/targets/ingester/src/index.js
@@ -1,0 +1,58 @@
+import { client } from "@shared/graphql-client";
+import { generateCdtnId } from "@shared/id-generator";
+
+import { cdtnDocumentsGen } from "./listDocuments";
+import { logger } from "./logger";
+
+logger.silent = true;
+const t0 = Date.now();
+
+const insertDocumentsMutation = `
+mutation insert_documents($document: documents_insert_input!) {
+  document: insert_documents_one(object: $document,  on_conflict: {
+    constraint: documents_initial_id_source_key,
+    update_columns: [title, source, slug, text, document]
+  }) {
+   cdtn_id
+  }
+}
+`;
+
+async function populate() {
+  for await (const docs of cdtnDocumentsGen()) {
+    console.error(`› ${docs[0].source}... ${docs.length} items`);
+
+    for (const doc of docs) {
+      const { id, title, text, slug, source, ...document } = doc;
+      const result = await client
+        .mutation(insertDocumentsMutation, {
+          document: {
+            cdtn_id: generateCdtnId(`${source}${id}`),
+            document,
+            initial_id: id,
+            meta_description: "",
+            slug,
+            source,
+            text,
+            title,
+          },
+        })
+        .toPromise();
+
+      if (result.error) {
+        console.error(result.error);
+        throw new Error(`insert document alert ${title}`);
+      }
+    }
+  }
+  //eslint-disable-next-line no-console
+  console.error(`done in ${(Date.now() - t0) / 1000} s`);
+}
+
+if (module === require.main) {
+  populate().catch((error) => {
+    console.error(error);
+    console.error(`done in ${(Date.now() - t0) / 1000} s`);
+    process.exit(1);
+  });
+}

--- a/targets/ingester/src/listDocuments.js
+++ b/targets/ingester/src/listDocuments.js
@@ -1,0 +1,156 @@
+import slugify from "@socialgouv/cdtn-slugify";
+import { SOURCES } from "@socialgouv/cdtn-sources";
+import find from "unist-util-find";
+import { selectAll } from "unist-util-select";
+
+import { getAgreementPages } from "./agreementPages";
+import { getFichesServicePublic } from "./fichesServicePublic";
+import { getVersions } from "./getSocialgouvVersions";
+import { logger } from "./logger";
+
+function parseIdcc(idcc) {
+  return parseInt(idcc, 10);
+}
+function getArticleUrl(id) {
+  return `https://www.legifrance.gouv.fr/affichCodeArticle.do;?idArticle=${id}&cidTexte=LEGITEXT000006072050`;
+}
+
+function fixArticleNum(id, num) {
+  if (num.match(/^annexe\s/i) && !num.includes("article")) {
+    return `${num} ${id}`;
+  }
+  return num;
+}
+
+/**
+ * Find duplicate slugs
+ * @param {AsyncIterable<(ingester.CdtnDocument)[]>} allDocuments is an iterable generator
+ */
+async function getDuplicateSlugs(allDocuments) {
+  /** @type {string[]} */
+  let slugs = [];
+  for await (const documents of allDocuments) {
+    slugs = slugs.concat(
+      documents.map(({ source, slug }) => `${source}/${slug}`)
+    );
+  }
+
+  return slugs
+    .map((slug) => ({ count: slugs.filter((s) => slug === s).length, slug }))
+    .filter(({ count }) => count > 1)
+    .reduce((state, { slug, count }) => ({ ...state, [slug]: count }), {});
+}
+/**
+ * @returns {AsyncIterable<ingester.CdtnDocument[]>}
+ */
+async function* cdtnDocumentsGen() {
+  const fichesMT = require("@socialgouv/fiches-travail-data/data/fiches-travail.json");
+  fichesMT.forEach((article) => (article.slug = slugify(article.title)));
+
+  logger.info("=== Code du travail ===");
+  yield selectAll(
+    "article",
+    require("@socialgouv/legi-data/data/LEGITEXT000006072050.json")
+  ).map(
+    ({ data: { id, num, dateDebut, nota, notaHtml, texte, texteHtml } }) => ({
+      dateDebut,
+      description: texte.slice(0, texte.indexOf("…", 150)),
+      html: texteHtml,
+      id,
+      slug: slugify(fixArticleNum(id, num)),
+      source: SOURCES.CDT,
+      text: `${texte}\n${nota}`,
+      title: fixArticleNum(id, num),
+      ...(nota.length > 0 && { notaHtml }),
+      url: getArticleUrl(id),
+    })
+  );
+
+  logger.info("=== Fiches SP ===");
+  yield getFichesServicePublic();
+
+  logger.info("=== Contributions ===");
+  yield require("@socialgouv/contributions-data/data/contributions.json").map(
+    ({ title, answers, id }) => {
+      const slug = slugify(title);
+      fixReferences(answers.generic);
+      answers.conventions.forEach(fixReferences);
+
+      return {
+        answers: {
+          ...answers,
+          generic: {
+            ...answers.generic,
+            markdown: answers.generic.markdown,
+          },
+        },
+        description: (answers.generic && answers.generic.description) || title,
+        excludeFromSearch: false,
+        id,
+        slug,
+        source: SOURCES.CONTRIBUTIONS,
+        text: (answers.generic && answers.generic.text) || title,
+        title,
+      };
+    }
+  );
+
+  logger.info("=== page fiches travail-emploi ===");
+  yield fichesMT.map(({ pubId, ...content }) => {
+    return {
+      id: pubId,
+      ...content,
+
+      source: SOURCES.SHEET_MT_PAGE,
+      /**
+       * text is empty here because text used for search (in elasticsearch)
+       * is in each sections and sections will be transform as searchable document
+       */
+      text: "",
+    };
+  });
+
+  logger.info("=== page Convention collective ===");
+  const ccnData = getAgreementPages();
+  yield ccnData.map(({ ...content }) => {
+    return {
+      ...content,
+      source: SOURCES.CCN_PAGE,
+    };
+  });
+}
+
+/**
+ * HACK @lionelb
+ * fix references is here only until migration of references in contributions
+ * will be done.
+ * fixReferences will resolve article num.
+ * For article withou num, it will use the parent section's name
+ */
+function fixReferences({ references = [], idcc = "generic" }) {
+  references.forEach((ref) => {
+    if (ref.title.startsWith("KALIARTI")) {
+      const tree = require(`@socialgouv/kali-data/data/${ref.agreement.id}.json`);
+      const parent = find(tree, (node) => {
+        return (
+          node.type === "section" &&
+          node.children.some((node) => node.data.id === ref.title)
+        );
+      });
+      if (parent) {
+        const node = parent.children.find((node) => node.data.id === ref.title);
+        ref.id = ref.title;
+        ref.title = node.data.num
+          ? `Article ${node.data.num}`
+          : parent.data.title;
+        if (!ref.title) {
+          console.error("article with no num", ref.id, ref.agreement.id, idcc);
+        }
+      } else {
+        console.error("can't fix ref for", ref.title, ref.agreement.id, idcc);
+      }
+    }
+  });
+}
+
+export { getDuplicateSlugs, cdtnDocumentsGen };

--- a/targets/ingester/src/logger.js
+++ b/targets/ingester/src/logger.js
@@ -1,0 +1,14 @@
+const {
+  createLogger,
+  format,
+  transports: { Console },
+} = require("winston");
+
+export const logger = createLogger({
+  level: "info",
+  transports: [
+    new Console({
+      format: format.prettyPrint(),
+    }),
+  ],
+});

--- a/targets/ingester/tsconfig.json
+++ b/targets/ingester/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "lib": ["es2019"],
+    "baseUrl": "."
+  },
+  "include": ["src", "@types"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,31 @@
   resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-11.0.0.tgz#719cf05fcc1abb6533610a2e0f5dd1e61eac14fe"
   integrity sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==
 
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
+"@data-forge/serialization@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@data-forge/serialization/-/serialization-1.0.1.tgz#2a963ea78154688f738e3465558b1c0a2d5963e2"
+  integrity sha512-EP7IWimh5JcDOISVoXvNIjUAqcPN1FkNWvuvjY3uzcswErxB8j93ldlUBvgvGEszqFRwMM3fpMF0HrISg5iBSQ==
+
+"@elastic/elasticsearch@^7.9.0":
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.9.1.tgz#40f1c38e8f70d783851c13be78a7cb346891c15e"
+  integrity sha512-NfPADbm9tRK/4ohpm9+aBtJ8WPKQqQaReyBKT225pi2oKQO1IzRlfM+OPplAvbhoH1efrSj1NKk27L+4BCrzXQ==
+  dependencies:
+    debug "^4.1.1"
+    decompress-response "^4.2.0"
+    ms "^2.1.1"
+    pump "^3.0.0"
+    secure-json-parse "^2.1.0"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -2736,6 +2761,17 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@socialgouv/cdtn-monolog@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@socialgouv/cdtn-monolog/-/cdtn-monolog-1.1.2.tgz#8e871d53b9437eb902be0208985e9e6835a8cff7"
+  integrity sha512-0G2dJexYac1Ts6TzvHw/XSOuJQ578kTQCQ0UskwQCNo9s5I/KaEBHHAam2fKDsSI6TWHNYlTX9mLHPsNqYbyWA==
+  dependencies:
+    "@elastic/elasticsearch" "^7.9.0"
+    data-forge "^1.8.10"
+    data-forge-fs "^0.0.8"
+    esm "^3.2.25"
+    winston "^3.3.3"
+
 "@socialgouv/cdtn-slugify@^4.31.1":
   version "4.31.1"
   resolved "https://registry.yarnpkg.com/@socialgouv/cdtn-slugify/-/cdtn-slugify-4.31.1.tgz#494ee2c9900e811197a3797638805fe6a6489287"
@@ -2748,7 +2784,7 @@
   resolved "https://registry.yarnpkg.com/@socialgouv/cdtn-sources/-/cdtn-sources-4.31.1.tgz#8bd3082ae4fb5d29218a07e32fa1e2f4ceb8dd63"
   integrity sha512-5M7GUXS5SYpUyvbKe/u4QJYgySl/I1JqrXwjhwvU7tpNxapQuyzuaQHoMADDYardDbPgsepXiBSCyMR6J57VYg==
 
-"@socialgouv/contributions-data@^2.19.0":
+"@socialgouv/contributions-data@^2.18.0", "@socialgouv/contributions-data@^2.19.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@socialgouv/contributions-data/-/contributions-data-2.19.0.tgz#05b11fe98bba67a23a5257fa1f8a7f09b019109b"
   integrity sha512-NbV5+Pxjw8qUesEDruk1uxyyMIRkWvcWeWwlBi80N3KgSipcocrZffs6RO3PqH+60IkC39z9YE2FalfmCdwPUw==
@@ -2757,6 +2793,16 @@
     node-fetch "^2.6.1"
     remark "^12.0.1"
     strip-markdown "^3.1.2"
+
+"@socialgouv/datafiller-data@^1.64.0":
+  version "1.65.0"
+  resolved "https://registry.yarnpkg.com/@socialgouv/datafiller-data/-/datafiller-data-1.65.0.tgz#42cbe142891a4f6767f55ed6057797ad963b037a"
+  integrity sha512-VdgVX1RltFBgynLtrGyWdQlO+RTy9RwQuHfsmmK+S8Kmn5EYWH/DSBal9aI2xYR3S7wDLMw25tdG0Gx4Z4tycw==
+  dependencies:
+    node-fetch "^2.6.1"
+    p-pipe "^3.1.0"
+    remark "^12.0.1"
+    remark-html "^12.0.0"
 
 "@socialgouv/datafiller-data@^1.66.0":
   version "1.66.0"
@@ -2779,7 +2825,7 @@
     eslint-plugin-react "~7.21.3"
     eslint-plugin-react-hooks "~4.1.2"
 
-"@socialgouv/eslint-config-recommended@^1.38.0":
+"@socialgouv/eslint-config-recommended@^1.30.0", "@socialgouv/eslint-config-recommended@^1.38.0":
   version "1.38.0"
   resolved "https://registry.yarnpkg.com/@socialgouv/eslint-config-recommended/-/eslint-config-recommended-1.38.0.tgz#429bb1ac7dab7f77bc5a81052f346a733cfc345e"
   integrity sha512-GEEsBFaPFTdfXKel/Y7V5X6JwhhwhUGajWW22RCo2HDA/kYBL9OPnJ5HjGUY7Pu8TAsY3i7+uasJ3+xydjAvfA==
@@ -2791,10 +2837,37 @@
     eslint-plugin-simple-import-sort "~5.0.3"
     eslint-plugin-sort-keys-fix "~1.1.1"
 
-"@socialgouv/fiches-travail-data@^3.221.0":
+"@socialgouv/fiches-travail-data@^3.220.0", "@socialgouv/fiches-travail-data@^3.221.0":
   version "3.221.0"
   resolved "https://registry.yarnpkg.com/@socialgouv/fiches-travail-data/-/fiches-travail-data-3.221.0.tgz#bf1877a442b172ccb167f8972f3f4a603dfd13c3"
   integrity sha512-Zu3R4ERMenMYxDZmKbkz2xSCHKXQ7whlBUwzH5O1q5/LaYjPekOIggdXSPLtf0hEOOzrCnFc7cmdz6llyMqFEQ==
+
+"@socialgouv/fiches-vdd@^1.172.0":
+  version "1.173.0"
+  resolved "https://registry.yarnpkg.com/@socialgouv/fiches-vdd/-/fiches-vdd-1.173.0.tgz#4c7a1990db5eec78f04a1260ca64ec86b6d006cd"
+  integrity sha512-ES6EtY74VGMeNceBxv9RTyex9rPplG9A69JFY3UjUSQHTNBcGHEwoze5dtoNBc9r9gdVkBJMI6zEs/mlvXLMGg==
+  dependencies:
+    node-fetch "^2.6.1"
+    ora "^5.1.0"
+    unzipper "^0.10.11"
+    xml-js "^1.6.11"
+
+"@socialgouv/kali-data@^1.115.0":
+  version "1.116.0"
+  resolved "https://registry.yarnpkg.com/@socialgouv/kali-data/-/kali-data-1.116.0.tgz#68a5cc4bcb09df7e4ae9d12a7b16ad67aa6dd609"
+  integrity sha512-B2TcFyKymFpvQFMyv2jZ1MpCik4kEaVqeXUiSjqJB7TRCDrvVJyft+uolfuS+2pHypd+diuKooZ9HSvipnpf7w==
+  dependencies:
+    unist-util-find "1.0.1"
+    unist-util-flat-filter "1.0.0"
+    unist-util-parents "1.0.3"
+
+"@socialgouv/legi-data@^1.40.0":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/@socialgouv/legi-data/-/legi-data-1.40.0.tgz#a819d3e03df9b968f4e00a79c7f3b01dbe55233a"
+  integrity sha512-v8W4zfRyOH/ZwKTkYsgsB5mcfB7GD1Q20c3CTkmaOYF07wiB6mM32VWcclT+BAES7shTpvWYGtvzV6oSPAsssA==
+  dependencies:
+    unist-util-find "1.0.1"
+    unist-util-parents "1.0.3"
 
 "@socialgouv/matomo-next@^1.1.2":
   version "1.1.2"
@@ -3112,7 +3185,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^14.11.5":
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.11.5", "@types/node@^14.6.4":
   version "14.11.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.5.tgz#fecad41c041cae7f2404ad4b2d0742fdb628b305"
   integrity sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==
@@ -3826,6 +3899,11 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -3855,6 +3933,11 @@ async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
+
+async@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
+  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -4068,6 +4151,11 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
+big-integer@^1.6.17:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -4082,6 +4170,14 @@ binary-extensions@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
+
+binary@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
+  integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
+  dependencies:
+    buffers "~0.1.1"
+    chainsaw "~0.1.0"
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -4102,6 +4198,11 @@ bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
+bluebird@~3.4.1:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+  integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
@@ -4296,6 +4397,11 @@ buffer-from@^1.0.0, buffer-from@^1.1.1:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer-indexof-polyfill@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz#d2732135c5999c64b277fcf9b1abe3498254729c"
+  integrity sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -4317,6 +4423,11 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffers@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
+  integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
 
 builtin-modules@^3.1.0:
   version "3.1.0"
@@ -4536,6 +4647,25 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
 
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
+chainsaw@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
+  integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
+  dependencies:
+    traverse ">=0.3.0 <0.4"
+
 chalk@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
@@ -4598,6 +4728,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chokidar@2.1.8, chokidar@^2.1.8:
   version "2.1.8"
@@ -4692,6 +4827,11 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-spinners@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.4.0.tgz#c6256db216b878cfba4720e719cec7cf72685d7f"
+  integrity sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==
+
 cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
@@ -4759,7 +4899,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-collapse-white-space@^1.0.2:
+collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
   integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
@@ -4777,7 +4917,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4796,10 +4936,39 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
+  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
+
+colors@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
+  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
+  dependencies:
+    color "3.0.x"
+    text-hex "1.0.x"
 
 columnify@^1.5.4:
   version "1.5.4"
@@ -5674,6 +5843,26 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-forge-fs@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/data-forge-fs/-/data-forge-fs-0.0.8.tgz#e487aa2ec71bada7d421e00872d7c07b99ab35bc"
+  integrity sha512-QmxcnkqtthsFMnQb1qFva2eXpMrPEmxWR3X05ghunFXnTRvZs2aJd+jsxwWZBl2MRE5l+ZT3fIP2IkAE7r3asA==
+  dependencies:
+    chai "^4.1.2"
+
+data-forge@^1.8.10:
+  version "1.8.11"
+  resolved "https://registry.yarnpkg.com/data-forge/-/data-forge-1.8.11.tgz#047947c0043baa55af74695cfa12ebc71d8b8053"
+  integrity sha512-mx9O6G9Izu0v5wE76KI7jMIL9zqj+N8DsDh5TMFiFBgQHk20i8lL2JwmA4GeK0kr5XIHEBhFi104/qvfCpiToA==
+  dependencies:
+    "@data-forge/serialization" "^1.0.0"
+    dayjs "^1.8.12"
+    easy-table "1.1.0"
+    json5 "^2.1.0"
+    numeral "^2.0.6"
+    papaparse "5.2.0"
+    typy "^3.0.1"
+
 data-uri-to-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.0.tgz#8a3088a5efd3f53c3682343313c6895d498eb8d7"
@@ -5699,6 +5888,11 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+dayjs@^1.8.12:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.1.tgz#201a755f7db5103ed6de63ba93a984141c754541"
+  integrity sha512-01NCTBg8cuMJG1OQc6PR7T66+AFYiPwgDvdJmvJBn29NGzIG+DIFxPLNjHzwz3cpFIvG+NcwIjP9hSaPVoOaDg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
@@ -5756,6 +5950,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 decompress-response@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-5.0.0.tgz#7849396e80e3d1eba8cb2f75ef4930f76461cb0f"
@@ -5767,6 +5968,13 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -6044,6 +6252,13 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+duplexer2@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
+  dependencies:
+    readable-stream "^2.0.2"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -6063,6 +6278,13 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+easy-table@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/easy-table/-/easy-table-1.1.0.tgz#86f9ab4c102f0371b7297b92a651d5824bc8cb73"
+  integrity sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=
+  optionalDependencies:
+    wcwidth ">=1.0.1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -6131,6 +6353,11 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -6465,7 +6692,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.10.0:
+eslint@^7.10.0, eslint@^7.8.1:
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.10.0.tgz#494edb3e4750fb791133ca379e786a8f648c72b9"
   integrity sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==
@@ -6805,6 +7032,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.4:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fastq@^1.6.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
@@ -6818,6 +7050,11 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fecha@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
+  integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -6975,6 +7212,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
 focus-lock@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
@@ -7109,6 +7351,16 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -7147,6 +7399,11 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-nonce@^1.0.0:
   version "1.0.1"
@@ -7512,7 +7769,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.3:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -7865,7 +8122,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7985,6 +8242,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-binary-path@^1.0.0:
   version "1.0.1"
@@ -8136,6 +8398,11 @@ is-hexadecimal@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
 is-negative-zero@^2.0.0:
   version "2.0.0"
@@ -8742,7 +9009,7 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^26.5.2:
+jest@^26.4.2, jest@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.5.2.tgz#c6791642b331fe7abd2f993b0a74aa546f7be0fb"
   integrity sha512-4HFabJVwsgDwul/7rhXJ3yFAF/aUkVIXiJWmgFxb+WMdZG39fVvOwYAs8/3r4AlFPc4m/n5sTMtuMbOL3kNtrQ==
@@ -8968,6 +9235,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 language-subtag-registry@~0.3.2:
   version "0.3.20"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz#a00a37121894f224f763268e431c55556b0c0755"
@@ -9044,7 +9316,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.4.0:
+lint-staged@^10.3.0, lint-staged@^10.4.0:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.4.0.tgz#d18628f737328e0bbbf87d183f4020930e9a984e"
   integrity sha512-uaiX4U5yERUSiIEQc329vhCTDDwUcSvKdRLsNomkYLRzijk3v8V9GWm2Nz0RMVB87VcuzLvtgy6OsjoH++QHIg==
@@ -9064,6 +9336,11 @@ lint-staged@^10.4.0:
     please-upgrade-node "^3.2.0"
     string-argv "0.3.1"
     stringify-object "^3.3.0"
+
+listenercount@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
+  integrity sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=
 
 listr2@^2.6.0:
   version "2.6.2"
@@ -9245,6 +9522,11 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
+lodash.iteratee@^4.5.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz#be4177db289a8ccc3c0990f1db26b5b22fc1554c"
+  integrity sha1-vkF32yiajMw8CZDx2ya1si/BVUw=
+
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -9301,6 +9583,22 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+logform@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.2.0.tgz#40f036d19161fc76b68ab50fdc7fe495544492f2"
+  integrity sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
+  dependencies:
+    colors "^1.2.1"
+    fast-safe-stringify "^2.0.4"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    triple-beam "^1.3.0"
+
+longest-streak@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-1.0.0.tgz#d06597c4d4c31b52ccb1f5d8f8fe7148eafd6965"
+  integrity sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU=
 
 longest-streak@^2.0.1:
   version "2.0.4"
@@ -9447,6 +9745,11 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-table@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-0.4.0.tgz#890c2c1b3bfe83fb00e4129b8e4cfe645270f9d1"
+  integrity sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE=
+
 markdown-table@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
@@ -9475,6 +9778,27 @@ mdast-util-definitions@^3.0.0:
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-3.0.1.tgz#06af6c49865fc63d6d7d30125569e2f7ae3d0a86"
   integrity sha512-BAv2iUm/e6IK/b2/t+Fx69EL/AGcq/IG2S+HxHjDJGfLJtd6i9SZUS76aC9cig+IEucsqxKTR0ot3m933R3iuA==
   dependencies:
+    unist-util-visit "^2.0.0"
+
+mdast-util-definitions@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz#c5c1a84db799173b4dcf7643cda999e440c24db2"
+  integrity sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==
+  dependencies:
+    unist-util-visit "^2.0.0"
+
+mdast-util-to-hast@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.0.tgz#744dfe7907bac0263398a68af5aba16d104a9a08"
+  integrity sha512-dRyAC5S4eDcIOdkz4jg0wXbUdlf+5YFu7KppJNHOsMaD7ql5bKIqVcvXYYkcrKjzUkfX8JsKFVMthsU8OWxQ+w==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    mdast-util-definitions "^4.0.0"
+    mdurl "^1.0.0"
+    unist-builder "^2.0.0"
+    unist-util-generated "^1.0.0"
+    unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
 mdast-util-to-hast@^9.0.0:
@@ -9787,7 +10111,7 @@ mkdirp@0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -9841,7 +10165,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mute-stream@~0.0.4:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -10370,6 +10694,11 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
+numeral@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/numeral/-/numeral-2.0.6.tgz#4ad080936d443c2561aed9f2197efffe25f4e506"
+  integrity sha1-StCAk21EPCVhrtnyGX7//iX05QY=
+
 nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
@@ -10495,12 +10824,19 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^2.0.0:
   version "2.0.1"
@@ -10563,6 +10899,20 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ora@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.1.0.tgz#b188cf8cd2d4d9b13fd25383bc3e5cba352c94f8"
+  integrity sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==
+  dependencies:
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.4.0"
+    is-interactive "^1.0.0"
+    log-symbols "^4.0.0"
+    mute-stream "0.0.8"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
 
 os-browserify@^0.3.0:
   version "0.3.0"
@@ -10743,6 +11093,11 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
+papaparse@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.2.0.tgz#97976a1b135c46612773029153dc64995caa3b7b"
+  integrity sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA==
+
 parallel-transform@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.2.0.tgz#9049ca37d6cb2182c3b1d2c720be94d14a5814fc"
@@ -10769,6 +11124,18 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-entities@^1.0.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-entities@^2.0.0:
   version "2.0.0"
@@ -10929,6 +11296,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
 pause-stream@0.0.11:
   version "0.0.11"
@@ -11357,6 +11729,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.13.5:
+  version "6.13.5"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.5.tgz#99e95e2fb7021db90a6f373f990c0c814b3812d8"
+  integrity sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -11688,7 +12069,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -11701,7 +12082,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.5.0, readable-stream@^3.6.0:
+"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -11849,6 +12230,30 @@ remark-html@^12.0.0:
     mdast-util-to-hast "^9.0.0"
     xtend "^4.0.1"
 
+remark-html@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/remark-html/-/remark-html-13.0.1.tgz#d5b2d8be01203e61fc37403167ca7584879ad675"
+  integrity sha512-K5KQCXWVz+harnyC+UVM/J9eJWCgjYRqFeZoZf2NgP0iFbuuw/RgMZv3MA34b/OEpGnstl3oiOUtZzD3tJ+CBw==
+  dependencies:
+    hast-util-sanitize "^3.0.0"
+    hast-util-to-html "^7.0.0"
+    mdast-util-to-hast "^10.0.0"
+
+remark-parse@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-1.1.0.tgz#c3ca10f9a8da04615c28f09aa4e304510526ec21"
+  integrity sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=
+  dependencies:
+    collapse-white-space "^1.0.0"
+    extend "^3.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+
 remark-parse@^8.0.0:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-8.0.3.tgz#9c62aa3b35b79a486454c690472906075f40c7e1"
@@ -11870,6 +12275,20 @@ remark-parse@^8.0.0:
     unist-util-remove-position "^2.0.0"
     vfile-location "^3.0.0"
     xtend "^4.0.1"
+
+remark-stringify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-1.1.0.tgz#a7105e25b9ee2bf9a49b75d2c423f11b06ae2092"
+  integrity sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=
+  dependencies:
+    ccount "^1.0.0"
+    extend "^3.0.0"
+    longest-streak "^1.0.0"
+    markdown-table "^0.4.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
 
 remark-stringify@^8.0.0:
   version "8.1.1"
@@ -11899,6 +12318,15 @@ remark@^12.0.1:
     remark-parse "^8.0.0"
     remark-stringify "^8.0.0"
     unified "^9.0.0"
+
+remark@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-5.1.0.tgz#cb463bd3dbcb4b99794935eee1cf71d7a8e3068c"
+  integrity sha1-y0Y709vLS5l5STXu4c9x16jjBow=
+  dependencies:
+    remark-parse "^1.1.0"
+    remark-stringify "^1.1.0"
+    unified "^4.1.1"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -12271,6 +12699,11 @@ section-iterator@^2.0.0:
   resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
   integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
 
+secure-json-parse@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.1.0.tgz#ae76f5624256b5c497af887090a5d9e156c9fb20"
+  integrity sha512-GckO+MS/wT4UogDyoI/H/S1L0MCcKS1XX/vp48wfmU7Nw4woBmb8mIpu4zPBQjKlRT88/bt9xdoV4111jPpNJA==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -12365,7 +12798,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@~1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -12446,6 +12879,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.4:
   version "1.0.5"
@@ -12647,6 +13087,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz#c80757383c28abf7296744998cbc106ae8b854ce"
   integrity sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -12709,6 +13154,11 @@ ssri@^7.0.0:
   dependencies:
     figgy-pudding "^3.5.1"
     minipass "^3.1.1"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^2.0.2:
   version "2.0.2"
@@ -12798,6 +13248,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@0.3.1:
   version "0.3.1"
@@ -12893,6 +13348,16 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-entities@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.2.tgz#a98417e5471fd227b3e45d3db1861c11caf668f7"
+  integrity sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 stringify-entities@^3.0.0, stringify-entities@^3.0.1:
   version "3.0.1"
@@ -13251,6 +13716,11 @@ text-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -13420,6 +13890,11 @@ traverse@0.6.6:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
+
 tree-kill@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -13454,6 +13929,11 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
   integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 trough@^1.0.0:
   version "1.0.5"
@@ -13523,7 +14003,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8, type-detect@^4.0.3:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.3, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -13598,6 +14078,11 @@ typescript@^4.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
+typy@^3.0.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/typy/-/typy-3.3.0.tgz#ed06e93f3329c87e3cee0df892929acffeb69eaa"
+  integrity sha512-Du53deMF9X9pSM3gVXDjLBq14BUfZWSGKfmmR1kTlg953RaIZehfc8fQuoAiW+SRO6bJsP+59mv1tsH8vwKghg==
+
 uglify-js@^3.1.4:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.1.tgz#32d274fea8aac333293044afd7f81409d5040d38"
@@ -13649,6 +14134,18 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
 
+unified@^4.1.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-4.2.1.tgz#76ff43aa8da430f6e7e4a55c84ebac2ad2cfcd2e"
+  integrity sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    has "^1.0.1"
+    once "^1.3.3"
+    trough "^1.0.0"
+    vfile "^1.0.0"
+
 unified@^9.0.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.0.tgz#67a62c627c40589edebbf60f53edfd4d822027f8"
@@ -13695,17 +14192,38 @@ unist-builder@^2.0.0:
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
 
+unist-util-find@1.0.1, unist-util-find@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-find/-/unist-util-find-1.0.1.tgz#1062bbb6928c7a97c6adc89b53745d4c46c222a2"
+  integrity sha1-EGK7tpKMepfGrcibU3RdTEbCIqI=
+  dependencies:
+    lodash.iteratee "^4.5.0"
+    remark "^5.0.1"
+    unist-util-visit "^1.1.0"
+
+unist-util-flat-filter@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-flat-filter/-/unist-util-flat-filter-1.0.0.tgz#44972de80c889462c444da8878f5576568a113c6"
+  integrity sha512-zjTmbMgyL1V7iUCnFaGLms9HtGbqK4d3YINqzu+wiMbau93GdiDGtJiB8lMhAyxAaxIAK2rOCeBCldF0FUreKQ==
+  dependencies:
+    unist-util-is "^4.0.0"
+
 unist-util-generated@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.5.tgz#1e903e68467931ebfaea386dae9ea253628acd42"
   integrity sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw==
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
 
 unist-util-is@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.2.tgz#c7d1341188aa9ce5b3cff538958de9895f14a5de"
   integrity sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==
 
-unist-util-parents@^1.0.3:
+unist-util-parents@1.0.3, unist-util-parents@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-parents/-/unist-util-parents-1.0.3.tgz#9730446164303c40c01bcbe03221d11bc9189a4d"
   integrity sha512-GA82HBLgPxR+qkOzbti/jxzmkMBDu8iS/mw58iCwLpCl9JpLyGxkVr7nsFpAX956qIsa5yKNKM5SeGS8yCY8Lw==
@@ -13716,6 +14234,13 @@ unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
   integrity sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
 
 unist-util-remove-position@^2.0.0:
   version "2.0.1"
@@ -13742,6 +14267,13 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
 unist-util-visit-parents@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-3.1.0.tgz#4dd262fb9dcfe44f297d53e882fc6ff3421173d5"
@@ -13749,6 +14281,13 @@ unist-util-visit-parents@^3.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
+
+unist-util-visit@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 unist-util-visit@^2.0.0:
   version "2.0.3"
@@ -13793,6 +14332,22 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unzipper@^0.10.11:
+  version "0.10.11"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.11.tgz#0b4991446472cbdb92ee7403909f26c2419c782e"
+  integrity sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==
+  dependencies:
+    big-integer "^1.6.17"
+    binary "~0.3.0"
+    bluebird "~3.4.1"
+    buffer-indexof-polyfill "~1.0.0"
+    duplexer2 "~0.1.4"
+    fstream "^1.0.12"
+    graceful-fs "^4.2.2"
+    listenercount "~1.0.1"
+    readable-stream "~2.3.6"
+    setimmediate "~1.0.4"
 
 upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
@@ -13941,6 +14496,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
 vfile-location@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.1.0.tgz#81cd8a04b0ac935185f4fce16f270503fc2f692f"
@@ -13953,6 +14513,11 @@ vfile-message@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
+
+vfile@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-1.4.0.tgz#c0fd6fa484f8debdb771f68c31ed75d88da97fe7"
+  integrity sha1-wP1vpIT43r23cfaMMe112I2pf+c=
 
 vfile@^4.0.0:
   version "4.2.0"
@@ -14024,7 +14589,7 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
 
-wcwidth@^1.0.0:
+wcwidth@>=1.0.1, wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
@@ -14156,6 +14721,29 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
+winston-transport@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
+  dependencies:
+    readable-stream "^2.3.7"
+    triple-beam "^1.2.0"
+
+winston@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
+  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.1.0"
+    is-stream "^2.0.0"
+    logform "^2.2.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
+
 "wonka@>= 4.0.9", wonka@^4.0.14:
   version "4.0.14"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.14.tgz#77d680a84e575ed15a9f975eb87d6c530488f3a4"
@@ -14263,6 +14851,13 @@ ws@^7.2.3:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
   integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+
+xml-js@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
+  dependencies:
+    sax "^1.2.4"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Génère et insère les documents provenant des packages de données `@socialgouv/data-*`
- code-du-travail
- fiche service-public
- page travail-emploi (le split sera assuré au moment de l'indexation dans ES)
- page convention collective (Le theming des réponses sera fait au moment de l'indexation dans ES) 
- contributions

Les documents ne contiennent pas la breadcrumb, à rajouter lors de l'indexation dans ES

⚠️  je n'ai pas mis les document des ccn dans ils faisaient doublons avec les pages CCN, donc coté cdtn, il faudra penser à modifier la recherche ccn pour qu'elle utilise les document page CCN


ps : Le typing avec typescript est en cours (mais je galère)