### PR TITLE
fix(ci): fix restore job initContainer

### DIFF
--- a/.k8s/__tests__/__snapshots__/generate-prod-restore.ts.snap
+++ b/.k8s/__tests__/__snapshots__/generate-prod-restore.ts.snap
@@ -245,7 +245,7 @@ spec:
             - name: PGHOST
               value: cdtnadmindevserver.postgres.database.azure.com
             - name: PGDATABASE
-              value: autodevops_8843083e
+              value: some-database
             - name: PGPASSWORD
               value: password_8843083e
             - name: PGUSER

--- a/.k8s/components/jobs/restore/db.ts
+++ b/.k8s/components/jobs/restore/db.ts
@@ -31,4 +31,13 @@ const manifests = restoreDbJob({
     .toString(),
 });
 
+// override initContainer PGDATABASE because this project pipeline use the legacy `db_SHA` convention instead of `autodevops_SHA`
+const job = manifests.find((m) => m.kind === "Job");
+if (job) {
+  //@ts-expect-error
+  job.spec.template.spec.initContainers[0].env.find(
+    (e: EnvVar) => e.name === "PGDATABASE"
+  ).value = process.env.BACKUP_DB_NAME;
+}
+
 export default manifests;


### PR DESCRIPTION
This project pipeline use the legacy `db_SHA` convention instead of `autodevops_SHA` at database creation.

So the restore job was waiting for the wrong database to be ready...