### PR TITLE
docs(dev): add documentation for developer

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -81,7 +81,7 @@ To access to the Hasura console, run this command:
 hasura console --envfile ../../.env --project targets/hasura
 ```
 
-A webpage is opened in your browser. The password is `admin1`.
+A webpage is opened in your browser. The password is `admin1` as set in the `.env` file (`HASURA_GRAPHQL_ADMIN_SECRET` key).
 
 > Start only the Hasura instance (it starts the postgreSQL as dependency):
 > ```sh

--- a/README-dev.md
+++ b/README-dev.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This git is a monorepo composed of 4 projects.
+This git repository is a monorepo composed of 4 projects.
 
 ### Hasura
 
@@ -131,5 +131,4 @@ That's all 🎉
 At this moment, the database is populated only by external documents (contributions, code du travail...). 
 All CDTN data (written by the CDTN team) are not populated in the database.
 An [issue](https://github.com/SocialGouv/cdtn-admin/issues/320) has been opened to find the better way to import data from the production into a dev environment.
-
 

--- a/README-dev.md
+++ b/README-dev.md
@@ -30,7 +30,7 @@ There is, at this moment (February 2021), 4 sources:
  * [@SocialGouv/kali-data](https://github.com/SocialGouv/kali-data)
  * [@SocialGouv/legi-data](https://github.com/SocialGouv/legi-data)
 
-Each github repo has released. In the release, we have the content as json. 
+Each GitHub repo uses releases to track changes. Each release exposes content as JSON.
 Ingester retrieves the last version and inject data into Hasura.
 
 ### alert-cli

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,0 +1,135 @@
+# Code du travail numérique - Administration - dev
+
+## URLs
+
+| Environnement                                              | URL                                                         |
+|------------------------------------------------------------|-------------------------------------------------------------|
+|    Production (access granted only for authorized IP)      |  <https://cdtn-admin.fabrique.social.gouv.fr/>              |
+
+## Overview
+
+This git is a monorepo composed of 4 projects.
+
+### Hasura
+
+Used to expose data through a GraphQL API.
+It contains the metadata and migrations for Hasura.
+
+See the [Hasura documentation](https://hasura.io/docs/1.0/graphql/core/index.html) for more information.
+
+### Ingester
+
+Used to populate the database with documents provided by external sources.
+
+There is, at this moment (February 2021), 4 sources:
+ * [@SocialGouv/contributions-data](https://github.com/SocialGouv/contributions-data)
+ * [@SocialGouv/fiches-travail-data](https://github.com/SocialGouv/fiches-travail-data)
+ * [@SocialGouv/fiches-vdd](https://github.com/SocialGouv/fiches-vdd)
+ * [@SocialGouv/kali-data](https://github.com/SocialGouv/kali-data)
+ * [@SocialGouv/legi-data](https://github.com/SocialGouv/legi-data)
+
+Each github repo has released. In the release, we have the content as json. 
+Ingester retrieves the last version and inject data into Hasura.
+
+### alert-cli
+
+Used to detect changes between external source packages.
+For each new release of an external packages, this script compares the content and insert diff in the database.
+
+See [documentation](targets/alert-cli/README.md) for more detail.
+
+## Setup
+
+Make sure you're using NodeJS 12+.
+
+```sh
+# Install all the packages
+$ yarn
+$ yarn build
+```
+
+It's easy to setup a new environment with docker compose :
+
+```sh
+docker-compose up
+```
+
+The docker compose performs several steps.
+
+### Configure a postgreSQL database
+
+A postgreSQL database is used to store the data exposed through a Hasura instance.
+
+> Start only the postgreSQL instance:
+> ```sh
+> docker-compose up postgres
+> ```
+
+### Configure a Hasura instance
+
+A Hasura instance is used to expose the data stored in postgreSQL through a GraphQL API. 
+See the [Hasura documentation](https://hasura.io/docs/1.0/graphql/core/index.html) for more information.
+
+This step creates a new Hasura instance with the schema, 
+and some data (see [metadata](targets/hasura/metadata) and [migrations](targets/hasura/migrations) files of hasura target).
+
+To access to the Hasura console, run this command:
+
+```sh
+hasura console --envfile ../../.env --project targets/hasura
+```
+
+A webpage is opened in your browser. The password is `admin1`.
+
+> Start only the Hasura instance (it starts the postgreSQL as dependency):
+> ```sh
+> docker-compose up hasura
+> ```
+
+### Inject documents
+
+A part of the content is based on documents retrieved from another services (code du travail, contributions, fiche travail/emploi...).
+
+This step runs the Ingester script and populate the documentation.
+
+This step doesn't work correctly at this moment, an (issue)[https://github.com/SocialGouv/cdtn-admin/issues/319] has been opened to fix it.
+
+> Run the Ingester (it starts Hasura as dependency):
+> ```sh
+> docker-compose up ingester
+> ```
+
+### Frontend
+
+An administration website is available to configure and inject custom data.
+
+This step starts the frontend project (based on `next.js`). 
+User and admin accounts are automatically created by the Hasura step.
+
+| Type         | Username                                | Password |
+|--------------|-----------------------------------------|----------|
+|    Admin     |  codedutravailnumerique@travail.gouv.fr | admin1   | 
+|    User      |  utilisateur@travail.gouv.fr            | ???      |
+
+Frontend is reachable at the address <http://localhost:3000>
+
+> Run the frontend (it starts Hasura as dependency):
+> ```sh
+> docker-compose up www
+> ```
+> or via npm
+> ```sh
+> yarn workspace frontend dev
+> ```
+
+That's all 🎉
+
+## How to ?
+
+### How to retrieve CDTN data from production ?
+
+At this moment, the database is populated only by external documents (contributions, code du travail...). 
+All CDTN data (written by the CDTN team) are not populated in the database.
+An [issue](https://github.com/SocialGouv/cdtn-admin/issues/320) has been opened to find the better way to import data from the production into a dev environment.
+
+

--- a/README-dev.md
+++ b/README-dev.md
@@ -16,7 +16,9 @@ Used to expose data through a GraphQL API.
 It contains the metadata and migrations for Hasura.
 
 See the [Hasura documentation](https://hasura.io/docs/1.0/graphql/core/index.html) for more information.
+We recommend to [install the hasura console](https://hasura.io/docs/1.0/graphql/core/hasura-cli/install-hasura-cli.html) which provides a graphql sandbox and an administration UI for hasura.
 
+` ``
 ### Ingester
 
 Used to populate the database with documents provided by external sources.
@@ -131,4 +133,3 @@ That's all 🎉
 At this moment, the database is populated only by external documents (contributions, code du travail...). 
 All CDTN data (written by the CDTN team) are not populated in the database.
 An [issue](https://github.com/SocialGouv/cdtn-admin/issues/320) has been opened to find the better way to import data from the production into a dev environment.
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Code du travail numérique - Administration
 
 > Administrating [code.travail.gouv.fr](https://code.travail.gouv.fr) content.
+
+## Développement
+
+Retrouvez toutes les infos techniques pour démarrer le projet sur [README-dev](./README-dev.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
       - hasura
     env_file:
       - .env
+    environment:
+      HASURA_GRAPHQL_ENDPOINT: "http://hasura:8080/v1/graphql"
 
 volumes:
   db_data:


### PR DESCRIPTION
J'ai ajouté de la documentation pour l'initialisation du projet pour un dev.

J'ai également corrigé, je crois que c'est un petit bug, sur le docker compose pour donner l'adresse de Hasura à l'Ingester.

Il y a deux issues pour des problèmes identifiés mais qui demande réflexion pour les corriger: https://github.com/SocialGouv/cdtn-admin/issues/319 et https://github.com/SocialGouv/cdtn-admin/issues/320 