### PR TITLE
fix(frontend): re-orgnaize imports for ace-editor

### DIFF
--- a/targets/frontend/src/components/editor/CodeEditor.js
+++ b/targets/frontend/src/components/editor/CodeEditor.js
@@ -1,8 +1,9 @@
+/* eslint-disable simple-import-sort/imports */
+import PropTypes from "prop-types";
+
+import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-json";
 import "ace-builds/src-noconflict/theme-github";
-
-import PropTypes from "prop-types";
-import AceEditor from "react-ace";
 
 export default function CodeEditor({ onChange, value }) {
   return (

--- a/targets/frontend/src/components/editor/CodeEditor.js
+++ b/targets/frontend/src/components/editor/CodeEditor.js
@@ -1,3 +1,4 @@
+// Imports order are important and can't be in alphabetical order.
 /* eslint-disable simple-import-sort/imports */
 import PropTypes from "prop-types";
 


### PR DESCRIPTION
un oubli lors de la derniere PR, l'ordre des import est imoprtant (d'où le commentaire pour désactiver la règle slint)