### PR TITLE
fix(ingester): handle legifrance new url style

### DIFF
--- a/targets/ingester/src/cli.js
+++ b/targets/ingester/src/cli.js
@@ -253,31 +253,31 @@ async function main() {
     if (args.dryRun || !documents || !documents.length) {
       continue;
     }
-    // const nbDocs = await initDocAvailabity(documents[0].source);
-    // console.log(`update availability of ${nbDocs} documents`);
-    // console.log(
-    //   ` › ready to ingest ${documents.length} documents from ${pkgName}`
-    // );
-    // const chunks = chunk(documents, 50);
-    // const inserts = await batchPromises(
-    //   chunks,
-    //   (docs) =>
-    //     pRetry(() => insertDocuments(docs), {
-    //       onFailedAttempt: (error) => {
-    //         console.error(
-    //           `insert failed ${error.attemptNumber}/${
-    //             error.retriesLeft + error.attemptNumber
-    //           }`,
-    //           error.name,
-    //           error.message
-    //         );
-    //       },
-    //       retries: 5,
-    //     }),
-    //   15
-    // );
-    // ids = ids.concat(inserts.flat());
-    // await updateVersion(pkgName, version);
+    const nbDocs = await initDocAvailabity(documents[0].source);
+    console.log(`update availability of ${nbDocs} documents`);
+    console.log(
+      ` › ready to ingest ${documents.length} documents from ${pkgName}`
+    );
+    const chunks = chunk(documents, 50);
+    const inserts = await batchPromises(
+      chunks,
+      (docs) =>
+        pRetry(() => insertDocuments(docs), {
+          onFailedAttempt: (error) => {
+            console.error(
+              `insert failed ${error.attemptNumber}/${
+                error.retriesLeft + error.attemptNumber
+              }`,
+              error.name,
+              error.message
+            );
+          },
+          retries: 5,
+        }),
+      15
+    );
+    ids = ids.concat(inserts.flat());
+    await updateVersion(pkgName, version);
   }
   return ids;
 }

--- a/targets/ingester/src/cli.js
+++ b/targets/ingester/src/cli.js
@@ -253,31 +253,31 @@ async function main() {
     if (args.dryRun || !documents || !documents.length) {
       continue;
     }
-    const nbDocs = await initDocAvailabity(documents[0].source);
-    console.log(`update availability of ${nbDocs} documents`);
-    console.log(
-      ` › ready to ingest ${documents.length} documents from ${pkgName}`
-    );
-    const chunks = chunk(documents, 50);
-    const inserts = await batchPromises(
-      chunks,
-      (docs) =>
-        pRetry(() => insertDocuments(docs), {
-          onFailedAttempt: (error) => {
-            console.error(
-              `insert failed ${error.attemptNumber}/${
-                error.retriesLeft + error.attemptNumber
-              }`,
-              error.name,
-              error.message
-            );
-          },
-          retries: 5,
-        }),
-      15
-    );
-    ids = ids.concat(inserts.flat());
-    await updateVersion(pkgName, version);
+    // const nbDocs = await initDocAvailabity(documents[0].source);
+    // console.log(`update availability of ${nbDocs} documents`);
+    // console.log(
+    //   ` › ready to ingest ${documents.length} documents from ${pkgName}`
+    // );
+    // const chunks = chunk(documents, 50);
+    // const inserts = await batchPromises(
+    //   chunks,
+    //   (docs) =>
+    //     pRetry(() => insertDocuments(docs), {
+    //       onFailedAttempt: (error) => {
+    //         console.error(
+    //           `insert failed ${error.attemptNumber}/${
+    //             error.retriesLeft + error.attemptNumber
+    //           }`,
+    //           error.name,
+    //           error.message
+    //         );
+    //       },
+    //       retries: 5,
+    //     }),
+    //   15
+    // );
+    // ids = ids.concat(inserts.flat());
+    // await updateVersion(pkgName, version);
   }
   return ids;
 }

--- a/targets/ingester/src/index.d.ts
+++ b/targets/ingester/src/index.d.ts
@@ -1,122 +1,134 @@
-import type { SourceValues } from "@socialgouv/cdtn-sources"
-import type { Answer, Question, DilaRef, GenericAnswer } from "@socialgouv/contributions-data-types"
+import type { SourceValues } from "@socialgouv/cdtn-sources";
+import type {
+  Answer,
+  Question,
+  DilaRef,
+  GenericAnswer,
+} from "@socialgouv/contributions-data-types";
 
-export as namespace ingester
+export as namespace ingester;
 
 type Document = {
-  id: string
-  description: string
-  title: string
-  source: SourceValues
-  text: string
-  slug: string
-  is_searchable: Boolean
-}
+  id: string;
+  description: string;
+  title: string;
+  source: SourceValues;
+  text: string;
+  slug: string;
+  is_searchable: Boolean;
+};
 
 type ExternalDocument = Document & {
-  url: string
-}
+  url: string;
+};
 
 type ExtendedQuestion = Omit<Question, "answers"> & {
   answers: {
-    generic: GenericAnswer,
+    generic: GenericAnswer;
     conventionAnswer?: Answer & {
-      shortName: string
-    }
-    conventions?: Answer[]
-  }
-}
+      shortName: string;
+    };
+    conventions?: Answer[];
+  };
+};
 
-type Contribution = Document & ExtendedQuestion
+type Contribution = Document & ExtendedQuestion;
 
 type LegiArticle = ExternalDocument & {
-  dateDebut: number
-  html: string
-}
+  dateDebut: number;
+  html: string;
+};
 
 type FicheServicePublic = ExternalDocument & {
-  date: string //"O1/01/2021"
-  raw: string
-  referencedTexts: ReferencedTexts[]
-  legalReferences: LegalReference[]
-}
+  date: string; //"O1/01/2021"
+  raw: string;
+  referencedTexts: ReferencedTexts[];
+};
 
 type FicheTravailEmploi = ExternalDocument & {
-  date: string // "30/09/2020",
-  intro: string,
-  sections: TravailEmploiSection[]
-}
+  date: string; // "30/09/2020",
+  intro: string;
+  sections: TravailEmploiSection[];
+};
 
 type TravailEmploiSection = {
-  title: string
-  anchor: string
-  html: string
-  text: string
-  description: string
-  references: LegalReference[]
-}
+  title: string;
+  anchor: string;
+  html: string;
+  text: string;
+  description: string;
+  references: LegalReference[];
+};
 
 type AgreementPage = Document & {
-  num: Number
-  date_publi?: string
-  effectif?: Number
-  mtime?: Number
-  shortTitle: string
-  answers: AgreementAnswer[]
-  url?: string,
-  articlesByTheme: AgreementArticleByBlock[]
-  synonymes?: string[]
-}
+  num: Number;
+  date_publi?: string;
+  effectif?: Number;
+  mtime?: Number;
+  shortTitle: string;
+  answers: AgreementAnswer[];
+  url?: string;
+  articlesByTheme: AgreementArticleByBlock[];
+  synonymes?: string[];
+};
 
 type AgreementAnswer = {
-  index: Number
-  references: DilaRef[]
-  slug: string
-  question: string
-  answer: string
-}
+  index: Number;
+  references: DilaRef[];
+  slug: string;
+  question: string;
+  answer: string;
+};
 
 type AgreementArticleByBlock = {
   bloc: string;
   articles: {
-    cid: string
-    id: string
-    section: string
-    title: string
+    cid: string;
+    id: string;
+    section: string;
+    title: string;
   }[];
 };
 
-
 type InternalReference = {
-  title: string
-  slug: string
-  type: Exclude<cdtnSources.SourceRoute, "external">
-}
+  title: string;
+  slug: string;
+  type: Exclude<cdtnSources.SourceRoute, "external">;
+};
 
 type ExternalReference = {
-  title: string
-  url: string
-  type: "external"
-}
+  title: string;
+  url: string;
+  type: "external";
+};
 
 type LegalReference = {
-  id: string
-  cid: string
-  title: string
-  type: "conventions_collectives" | "code_du_travail"
-  url: string
-  slug: string
-}
+  id: string;
+  cid: string;
+  title: string;
+  type: "conventions_collectives" | "code_du_travail";
+  url: string;
+  slug: string;
+};
 
-type ReferencedTexts = ExternalReference | InternalReference
-
+type ReferencedTexts = ExternalReference | InternalReference;
 
 /** Document type */
-type CdtnDocument = Contribution | LegiArticle | AgreementPage | FicheServicePublic | FicheTravailEmploi
+type CdtnDocument =
+  | Contribution
+  | LegiArticle
+  | AgreementPage
+  | FicheServicePublic
+  | FicheTravailEmploi;
 
-type referenceResolver = (id: string) => (import("@socialgouv/legi-data-types").CodeSection | import("@socialgouv/legi-data-types").CodeArticle | import("@socialgouv/kali-data").AgreementSection | import("@socialgouv/kali-data").AgreementArticle)[]
-
-
+type referenceResolver = (
+  id: string
+) => (
+  | import("@socialgouv/legi-data-types").CodeSection
+  | import("@socialgouv/legi-data-types").CodeArticle
+  | import("@socialgouv/kali-data").AgreementSection
+  | import("@socialgouv/kali-data").AgreementArticle
+)[];
 
 // type EditorialDocument = Document & {
 //   date: string

--- a/targets/ingester/src/transform/fichesServicePublic/__tests__/parseReferences.test.js
+++ b/targets/ingester/src/transform/fichesServicePublic/__tests__/parseReferences.test.js
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "@jest/globals";
+import { SOURCES } from "@socialgouv/cdtn-sources";
+
+import { extractNewReference, extractOldReference } from "../parseReference";
+
+/** @type{import("@socialgouv/kali-data-types").IndexedAgreement[]} */
+const agreements = [
+  {
+    active: true,
+    date_publi: "2019-02-15T00:00:00.000Z",
+    etat: "VIGUEUR_NON_ETEN",
+    id: "KALICONT123",
+    mtime: 1561146467,
+    nature: "IDCC",
+    num: 123,
+    shortTitle: "convention 123",
+    texte_de_base: "KALITEXT123",
+    title: "Convention collective nationale des 123",
+    url:
+      "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT123",
+  },
+];
+const referenceResolver = jest.fn().mockImplementation((id) => {
+  if (id === "LEGISCTA42")
+    return [
+      {
+        children: [
+          {
+            data: {
+              id: "LEGIARTI42",
+              num: "L42-1",
+            },
+            type: "article",
+          },
+          {
+            data: {
+              id: "LEGIARTI43",
+              num: "L43-1",
+            },
+            type: "article",
+          },
+        ],
+        data: {
+          id: "LEGISCTA42",
+          num: "L42",
+        },
+        type: "section",
+      },
+    ];
+  if (id === "LEGIARTI42")
+    return [
+      {
+        data: {
+          id: "LEGIARTI42",
+          num: "L42-1",
+        },
+        type: "article",
+      },
+    ];
+  return [];
+});
+
+const external = {
+  title: "external",
+  type: SOURCES.EXTERNALS,
+  url: "https://legi.url/affichJuriJudi.do?idTexte=JURITEXT000007023096",
+};
+const external2 = {
+  title: "external",
+  type: SOURCES.EXTERNALS,
+  url: "https://legi.url/circulaire/id/39848",
+};
+
+const article42 = {
+  slug: "l42-1",
+  title: "L42-1",
+  type: SOURCES.CDT,
+};
+const article43 = {
+  slug: "l43-1",
+  title: "L43-1",
+  type: SOURCES.CDT,
+};
+const kali = {
+  slug: "123-convention-123",
+  title: "convention 123",
+  type: SOURCES.CCN,
+};
+const section42 = [article42, article43];
+
+describe("extractNewReference", () => {
+  test.each([
+    ["https://legi.url/codes/id/LEGISCTA42", "L42", section42],
+    ["/codes/section_lc/LEGITEXT000006072050/LEGISCTA42", "L42", section42],
+    ["https://legi.url/codes/article_lc/LEGIARTI42/", "L42-1", [article42]],
+    ["https://legi.url/codes/id/LEGIARTI42/", "L42-1", [article42]],
+    ["https://legi.url/conv_coll/id/KALICONT123", "convention 123", [kali]],
+    ["https://legi.url/circulaire/id/39848", "external", [external2]],
+  ])(`it should extract new reference from %p`, (url, label, reference) => {
+    expect(
+      extractNewReference(url, label, referenceResolver, agreements)
+    ).toEqual(reference);
+  });
+});
+
+describe("extractOldReference", () => {
+  test.each([
+    [
+      "https://legi.url/affichCode.do?cidTexte=LEGITEXT000006072050&idSectionTA=LEGISCTA42",
+      "L42",
+      section42,
+    ],
+
+    [
+      "https://legi.url/affichCode.do?idArticle=LEGIARTI42&idSectionTA=LEGISCTA42&cidTexte=LEGITEXT000006072050",
+      "L42-1",
+      [article42],
+    ],
+    [
+      "https://legi.url/affichCodeArticle.do;?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI42",
+      "L42-1",
+      [article42],
+    ],
+    [
+      "https://legi.url/affichIDCC.do?cidTexte=KALITEXT000005670044&idSectionTA=KALISCTA000005747382&idConvention=KALICONT123",
+      "convention 123",
+      [kali],
+    ],
+    [
+      "https://legi.url/affichJuriJudi.do?idTexte=JURITEXT000007023096",
+      "external",
+      [external],
+    ],
+  ])(`it should extract old reference for %s %s`, (url, label, reference) => {
+    expect(
+      extractOldReference(url, label, referenceResolver, agreements)
+    ).toEqual(reference);
+  });
+});

--- a/targets/ingester/src/transform/fichesServicePublic/format.js
+++ b/targets/ingester/src/transform/fichesServicePublic/format.js
@@ -64,7 +64,7 @@ export function format(fiche, resolveCdtReference, agreements) {
     (el) => el.name === "Reference"
   );
 
-  const [legalReferences, referencedTexts] = parseReferences(
+  const referencedTexts = parseReferences(
     references,
     resolveCdtReference,
     agreements
@@ -74,7 +74,6 @@ export function format(fiche, resolveCdtReference, agreements) {
     date,
     description,
     id,
-    legalReferences,
     raw: JSON.stringify(publication),
     referencedTexts,
     source: SOURCES.SHEET_SP,

--- a/targets/ingester/src/transform/fichesServicePublic/parseReference.js
+++ b/targets/ingester/src/transform/fichesServicePublic/parseReference.js
@@ -20,7 +20,6 @@ function isCodeDuTravail(qs) {
   return qs.cidTexte === "LEGITEXT000006072050";
 }
 
-
 /**
  * determine url type based on qs params
  * @param {{[key:string]:string}} qs
@@ -144,7 +143,7 @@ export function extractOldReference(
           console.error(
             `extractOldReferences: unkown article id ${qs.idArticle}, maybe reference is obsolete`
           );
-          return [];
+          return [externalReference(url, label)];
         }
         return [cdtArticleReference(article)];
       }
@@ -158,7 +157,10 @@ export function extractOldReference(
           console.error(
             `extractOldReferences: unkown section id ${qs.idSectionTA}, maybe reference is obsolete`
           );
-          return [];
+          return [externalReference(url, label)];
+        }
+        if (section.children.every((child) => child.type !== "article")) {
+          return [externalReference(url, label)];
         }
         return section.children.flatMap((child) => {
           if (child.type !== "article") {
@@ -170,7 +172,7 @@ export function extractOldReference(
       console.error(
         `extractOldReferences: cannot extract article reference from url ${url}`
       );
-      return [];
+      return [externalReference(url, label)];
     }
 
     case "convention-collective": {
@@ -181,7 +183,7 @@ export function extractOldReference(
         console.error(
           `extractOldReferences: unkown convention id ${qs.idConvention}`
         );
-        return [];
+        return [externalReference(url, label)];
       }
       return [agreementReference(convention)];
     }
@@ -246,6 +248,9 @@ export function extractNewReference(
       ));
 
       if (section) {
+        if (section.children.every((child) => child.type !== "article")) {
+          return [externalReference(url, label)];
+        }
         return section.children.flatMap((child) => {
           if (child.type !== "article") {
             return [];
@@ -265,7 +270,7 @@ export function extractNewReference(
       console.error(
         `extractOldReferences: unkown convention id ${kalicontainerId}`
       );
-      return [];
+      return [externalReference(url, label)];
     }
     return [agreementReference(convention)];
   }

--- a/targets/ingester/src/transform/fichesServicePublic/parseReference.js
+++ b/targets/ingester/src/transform/fichesServicePublic/parseReference.js
@@ -1,9 +1,8 @@
-// Do we really need this one ?
 import slugify from "@socialgouv/cdtn-slugify";
 import { SOURCES } from "@socialgouv/cdtn-sources";
 import queryString from "query-string";
 
-import { articleToReference, fixArticleNum } from "../../lib/referenceResolver";
+import { fixArticleNum } from "../../lib/referenceResolver";
 
 /**
  * check if qs params come from a ccn url
@@ -20,13 +19,7 @@ function isConventionCollective(qs) {
 function isCodeDuTravail(qs) {
   return qs.cidTexte === "LEGITEXT000006072050";
 }
-/**
- * check if qs params come from a jo url
- * @param {{[key:string]:string}} qs
- */
-function isJournalOfficiel(qs) {
-  return (qs.cidTexte || "").includes("JORFTEXT");
-}
+
 
 /**
  * determine url type based on qs params
@@ -40,98 +33,242 @@ const getTextType = (qs) => {
   if (isConventionCollective(qs)) {
     return "convention-collective";
   }
-  if (isJournalOfficiel(qs)) {
-    return "journal-officiel";
-  }
   return null;
 };
+
+/**
+ *
+ * @param {string} url
+ */
+function isPreviousLegifranceUrl(url) {
+  return /affich.+\.do/.test(url);
+}
+
+/**
+ *
+ * @param {import("@socialgouv/legi-data-types").CodeArticle} article
+ */
+function cdtArticleReference(article) {
+  return {
+    slug: slugify(fixArticleNum(article.data.id, article.data.num)),
+    title: article.data.num,
+    type: SOURCES.CDT,
+  };
+}
+/**
+ *
+ * @param {import("@socialgouv/kali-data-types").IndexedAgreement} convention
+ */
+function agreementReference(convention) {
+  const { num, shortTitle } = convention;
+  return {
+    slug: slugify(`${num}-${shortTitle}`.substring(0, 80)),
+    title: shortTitle,
+    type: SOURCES.CCN,
+  };
+}
+/**
+ *
+ * @param {string} url
+ * @param {string} label
+ */
+function externalReference(url, label) {
+  return {
+    title: label,
+    type: SOURCES.EXTERNALS,
+    url,
+  };
+}
 
 /**
  * @param {import("@socialgouv/fiches-vdd-types").RawJson[]} references
  * @param {ingester.referenceResolver} resolveCdtReference
  * @param {import("@socialgouv/kali-data-types").IndexedAgreement[]} agreements
- * @returns {[ingester.LegalReference[], ingester.ReferencedTexts[]]}
+ * @returns { ingester.ReferencedTexts[] }
  */
 export function parseReferences(references, resolveCdtReference, agreements) {
-  /** @type {ingester.LegalReference[]} */
-  const legalReferences = [];
-
-  /** @type {ingester.ReferencedTexts[]} */
+  /** @type {ingester.ReferencedTexts[][]} */
   const referencedTexts = [];
 
   for (const reference of references) {
     const { URL: url } = reference.attributes;
-    const qs = /** @type {{[key:string]: string}} */ (queryString.parse(
-      url.split("?")[1]
-    ));
-    const type = getTextType(qs);
-    switch (type) {
-      case "code-du-travail": {
-        if (qs.idArticle) {
-          const [
-            article,
-          ] = /** @type {import("@socialgouv/legi-data-types").CodeArticle[]} */ (resolveCdtReference(
-            qs.idArticle
-          ));
-          if (!article) {
-            break;
-          }
-          legalReferences.push(articleToReference(article));
-          referencedTexts.push({
-            slug: slugify(fixArticleNum(article.data.id, article.data.num)),
-            title: article.data.num,
-            type: SOURCES.CDT,
-          });
-        }
-        if (qs.idSectionTA) {
-          const [
-            section,
-          ] = /** @type {import("@socialgouv/legi-data-types").CodeSection[]} */ (resolveCdtReference(
-            qs.idSectionTA
-          ));
-          if (!section) {
-            break;
-          }
-          for (const child of section.children) {
-            if (child.type !== "article") {
-              break;
-            }
-            legalReferences.push(articleToReference(child));
-            referencedTexts.push({
-              slug: slugify(fixArticleNum(child.data.id, child.data.num)),
-              title: child.data.num,
-              type: SOURCES.CDT,
-            });
-          }
-        }
-        break;
-      }
+    const label = reference.children[0].children[0].text;
+    const refExtractor = isPreviousLegifranceUrl(url)
+      ? extractOldReference
+      : extractNewReference;
 
-      case "convention-collective": {
-        const convention = agreements.find(
-          (convention) => convention.id === qs.idConvention
+    const refs = refExtractor(url, label, resolveCdtReference, agreements);
+    referencedTexts.push(refs);
+  }
+  return referencedTexts.flat();
+}
+/**
+ * @param {string} url
+ * @param {string} label
+ * @param {ingester.referenceResolver} resolveCdtReference
+ * @param {import("@socialgouv/kali-data-types").IndexedAgreement[]} agreements
+ * @returns {ingester.ReferencedTexts[]}
+ */
+export function extractOldReference(
+  url,
+  label,
+  resolveCdtReference,
+  agreements
+) {
+  /**
+   * Typologie des anciens liens legifrance
+   *
+   * /affichCode.do?cidTexte=LEGITEXT000006072050&idSectionTA=LEGISCTA000033444780
+   * /affichCode.do?idArticle=LEGIARTI000006526850&idSectionTA=LEGISCTA000006182537&cidTexte=LEGITEXT000006071191
+   * /affichCodeArticle.do;?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000036467594
+   * /affichIDCC.do?cidTexte=KALITEXT000005670044&idSectionTA=KALISCTA000005747382&idConvention=KALICONT000005635534
+   * /affichJuriJudi.do?idTexte=JURITEXT000007023096
+   * /affichTexte.do;?cidTexte=JORFTEXT000034298773
+   * /affichTexteArticle.do?cidTexte=JORFTEXT000029953502&idArticle=JORFARTI000029953537
+   *
+   */
+  const qs = /** @type {{[key:string]: string}} */ (queryString.parse(
+    url.split("?")[1]
+  ));
+
+  const type = getTextType(qs);
+  switch (type) {
+    case "code-du-travail": {
+      if (qs.idArticle) {
+        const [
+          article,
+        ] = /** @type {import("@socialgouv/legi-data-types").CodeArticle[]} */ (resolveCdtReference(
+          qs.idArticle
+        ));
+        if (!article) {
+          console.error(
+            `extractOldReferences: unkown article id ${qs.idArticle}, maybe reference is obsolete`
+          );
+          return [];
+        }
+        return [cdtArticleReference(article)];
+      }
+      if (qs.idSectionTA) {
+        const [
+          section,
+        ] = /** @type {import("@socialgouv/legi-data-types").CodeSection[]} */ (resolveCdtReference(
+          qs.idSectionTA
+        ));
+        if (!section) {
+          console.error(
+            `extractOldReferences: unkown section id ${qs.idSectionTA}, maybe reference is obsolete`
+          );
+          return [];
+        }
+        return section.children.flatMap((child) => {
+          if (child.type !== "article") {
+            return [];
+          }
+          return [cdtArticleReference(child)];
+        });
+      }
+      console.error(
+        `extractOldReferences: cannot extract article reference from url ${url}`
+      );
+      return [];
+    }
+
+    case "convention-collective": {
+      const convention = agreements.find(
+        (convention) => convention.id === qs.idConvention
+      );
+      if (!convention) {
+        console.error(
+          `extractOldReferences: unkown convention id ${qs.idConvention}`
         );
-        if (!convention) {
-          break;
-        }
-        const { num, shortTitle } = convention;
-        referencedTexts.push({
-          slug: slugify(`${num}-${shortTitle}`.substring(0, 80)),
-          title: shortTitle,
-          type: SOURCES.CCN,
-        });
-        break;
+        return [];
       }
+      return [agreementReference(convention)];
+    }
+    // all other type fall as external link
+    default: {
+      return [externalReference(url, label)];
+    }
+  }
+}
 
-      case "journal-officiel": {
-        referencedTexts.push({
-          title: reference.children[0].children[0].text,
-          type: SOURCES.EXTERNALS,
-          url,
+/**
+ * @param {string} url
+ * @param {string} label
+ * @param {ingester.referenceResolver} resolveCdtReference
+ * @param {import("@socialgouv/kali-data-types").IndexedAgreement[]} agreements
+ * @returns {ingester.ReferencedTexts[]}
+ */
+export function extractNewReference(
+  url,
+  label,
+  resolveCdtReference,
+  agreements
+) {
+  /**
+   * typologie des nouveaux liens legifrance que l'on trouve dans les fiches service-public.fr
+   *
+   * /codes/id/LEGIARTI000041973733/: affiche un article et la section qui le contient
+   * /codes/article_lc/LEGIARTI000041973733/ : affiche l'article seul
+   * /codes/id/LEGISCTA000006156295 : affiche un section
+   * /codes/section_lc/LEGITEXT000006072050/LEGISCTA000006177917 affiche une section
+   * /conv_coll/id/KALICONT000005635598/ : affiche un convention collective
+   * /loda/article_lc/LEGIARTI000038836271/
+   * /loda/id/JORFTEXT000000196442/
+   * /circulaire/id/39848
+   * /download/pdf/circ?id=44449
+   * /eli/arrete/2016/12/5/AFSS1628753A/jo/texte
+   * /eli/decret/2014/12/30/ETST1429039D/jo/texte
+   * /loi/2018/12/22/CPAX1824950L/jo/article_18
+   * /article_jo/JORFARTI000042665320
+   * /id/JORFTEXT000000599731
+   * /jorf/id/JORFTEXT000042748814
+   *
+   */
+
+  if (/\/codes\//.test(url)) {
+    if (/LEGIARTI/.test(url)) {
+      const [, articleId] = url.match(/(LEGIARTI\w+)(\W|$)/) || [];
+      const [
+        article,
+      ] = /** @type {import("@socialgouv/legi-data-types").CodeArticle[]} */ (resolveCdtReference(
+        articleId
+      ));
+      if (article) {
+        return [cdtArticleReference(article)];
+      }
+    } else if (/LEGISCTA/.test(url)) {
+      const [, sectionId] = url.match(/(LEGISCTA\w+)(\W|$)/) || [];
+      const [
+        section,
+      ] = /** @type {import("@socialgouv/legi-data-types").CodeSection[]} */ (resolveCdtReference(
+        sectionId
+      ));
+
+      if (section) {
+        return section.children.flatMap((child) => {
+          if (child.type !== "article") {
+            return [];
+          }
+          return [cdtArticleReference(child)];
         });
-        break;
       }
     }
   }
-  return [legalReferences, referencedTexts];
+
+  if (/\/conv_coll\//.test(url)) {
+    const [, kalicontainerId] = url.match(/(KALICONT\w+)(\W|$)/) || [];
+    const convention = agreements.find(
+      (convention) => convention.id === kalicontainerId
+    );
+    if (!convention) {
+      console.error(
+        `extractOldReferences: unkown convention id ${kalicontainerId}`
+      );
+      return [];
+    }
+    return [agreementReference(convention)];
+  }
+
+  return [externalReference(url, label)];
 }


### PR DESCRIPTION
- handle the new legifrance url
-  every link which does not belong to cdt or kali  is considered an external link ( we re-use the label from the service-public data )  
closes #332 