### PR TITLE
feat: ajouter des fiches SP à la volée

### DIFF
--- a/shared/sheet-sp-formater/package.json
+++ b/shared/sheet-sp-formater/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@shared/sheet-sp-formater",
+  "version": "1.0.0-alpha.1",
+  "main": "src/index.js",
+  "module": "src/index.js",
+  "types": "src/index.d.ts",
+  "private": true,
+  "scripts": {}
+}

--- a/shared/sheet-sp-formater/src/index.d.ts
+++ b/shared/sheet-sp-formater/src/index.d.ts
@@ -1,0 +1,47 @@
+import type { SourceValues } from "@socialgouv/cdtn-sources";
+
+export as namespace references
+
+type Document = {
+  id: string;
+  description: string;
+  title: string;
+  source: SourceValues;
+  text: string;
+  slug: string;
+  is_searchable: Boolean;
+};
+
+type ExternalDocument = Document & {
+  url: string;
+};
+
+type FicheServicePublic = ExternalDocument & {
+  date: string; //"O1/01/2021"
+  raw: string;
+  referencedTexts: ReferencedTexts[];
+};
+
+type referenceResolver = (
+  id: string
+) => (
+  | import("@socialgouv/legi-data-types").CodeSection
+  | import("@socialgouv/legi-data-types").CodeArticle
+  | import("@socialgouv/kali-data").AgreementSection
+  | import("@socialgouv/kali-data").AgreementArticle
+)[];
+
+
+type InternalReference = {
+  title: string;
+  slug: string;
+  type: Exclude<cdtnSources.SourceRoute, "external">;
+};
+
+type ExternalReference = {
+  title: string;
+  url: string;
+  type: "external";
+};
+
+type ReferencedTexts = ExternalReference | InternalReference;

--- a/shared/sheet-sp-formater/src/index.js
+++ b/shared/sheet-sp-formater/src/index.js
@@ -1,4 +1,5 @@
 import { SOURCES } from "@socialgouv/cdtn-sources";
+import slugify from "@socialgouv/cdtn-slugify";
 
 import { parseReferences } from "./parseReference.js";
 
@@ -31,9 +32,9 @@ function getText(element) {
 /**
  *
  * @param {import("@socialgouv/fiches-vdd-types").RawJson} fiche
- * @param {ingester.referenceResolver} resolveCdtReference
+ * @param {references.referenceResolver} resolveCdtReference
  * @param {import("@socialgouv/kali-data-types").IndexedAgreement[]} agreements
- * @returns {Pick<ingester.FicheServicePublic, Exclude<keyof ingester.FicheServicePublic, keyof {slug, is_searchable: Boolean}>> }
+ * @returns {Pick<references.FicheServicePublic, Exclude<keyof references.FicheServicePublic, keyof {is_searchable: Boolean}>> }
  */
 export function format(fiche, resolveCdtReference, agreements) {
   const publication = fiche.children[0];
@@ -79,6 +80,7 @@ export function format(fiche, resolveCdtReference, agreements) {
     source: SOURCES.SHEET_SP,
     text,
     title,
+    slug: slugify(title),
     url,
   };
 }

--- a/shared/sheet-sp-formater/src/parseReference.js
+++ b/shared/sheet-sp-formater/src/parseReference.js
@@ -2,8 +2,6 @@ import slugify from "@socialgouv/cdtn-slugify";
 import { SOURCES } from "@socialgouv/cdtn-sources";
 import queryString from "query-string";
 
-import { fixArticleNum } from "../../lib/referenceResolver";
-
 /**
  * check if qs params come from a ccn url
  * @param {{[key:string]:string}} qs
@@ -48,8 +46,13 @@ function isPreviousLegifranceUrl(url) {
  * @param {import("@socialgouv/legi-data-types").CodeArticle} article
  */
 function cdtArticleReference(article) {
+  const num = article.data.num;
   return {
-    slug: slugify(fixArticleNum(article.data.id, article.data.num)),
+    slug: slugify(
+      num.match(/^annexe\s/i) && !num.includes("article")
+        ? `${num} ${article.data.id}`
+        : num
+    ),
     title: article.data.num,
     type: SOURCES.CDT,
   };
@@ -81,12 +84,12 @@ function externalReference(url, label) {
 
 /**
  * @param {import("@socialgouv/fiches-vdd-types").RawJson[]} references
- * @param {ingester.referenceResolver} resolveCdtReference
+ * @param {references.referenceResolver} resolveCdtReference
  * @param {import("@socialgouv/kali-data-types").IndexedAgreement[]} agreements
- * @returns { ingester.ReferencedTexts[] }
+ * @returns { references.ReferencedTexts[] }
  */
 export function parseReferences(references, resolveCdtReference, agreements) {
-  /** @type {ingester.ReferencedTexts[][]} */
+  /** @type {references.ReferencedTexts[][]} */
   const referencedTexts = [];
 
   for (const reference of references) {
@@ -104,9 +107,9 @@ export function parseReferences(references, resolveCdtReference, agreements) {
 /**
  * @param {string} url
  * @param {string} label
- * @param {ingester.referenceResolver} resolveCdtReference
+ * @param {references.referenceResolver} resolveCdtReference
  * @param {import("@socialgouv/kali-data-types").IndexedAgreement[]} agreements
- * @returns {ingester.ReferencedTexts[]}
+ * @returns {references.ReferencedTexts[]}
  */
 export function extractOldReference(
   url,
@@ -197,9 +200,9 @@ export function extractOldReference(
 /**
  * @param {string} url
  * @param {string} label
- * @param {ingester.referenceResolver} resolveCdtReference
+ * @param {references.referenceResolver} resolveCdtReference
  * @param {import("@socialgouv/kali-data-types").IndexedAgreement[]} agreements
- * @returns {ingester.ReferencedTexts[]}
+ * @returns {references.ReferencedTexts[]}
  */
 export function extractNewReference(
   url,

--- a/shared/sheet-sp-formater/tsconfig.json
+++ b/shared/sheet-sp-formater/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "lib": ["es2020"],
+    "module": "esnext",
+    "moduleResolution": "Node"
+  },
+  "include": ["src", "@types"]
+}

--- a/targets/frontend/Dockerfile
+++ b/targets/frontend/Dockerfile
@@ -7,6 +7,8 @@ COPY shared/graphql-client/src /app/shared/graphql-client/src
 COPY shared/graphql-client/package.json /app/shared/graphql-client/
 COPY shared/id-generator/src /app/shared/id-generator/src
 COPY shared/id-generator/package.json /app/shared/id-generator/
+COPY shared/sheet-sp-formater/src /app/shared/sheet-sp-formater/src
+COPY shared/sheet-sp-formater/package.json /app/shared/sheet-sp-formater/
 COPY targets/frontend/package.json /app/targets/frontend/
 
 RUN  npx @socialgouv/yarn-workspace-focus-install --cwd targets/frontend --production -- --cache-folder /dev/shm/yarn

--- a/targets/frontend/next.config.js
+++ b/targets/frontend/next.config.js
@@ -4,6 +4,7 @@ const withSourceMaps = require("@zeit/next-source-maps")();
 const withTM = require("next-transpile-modules")([
   "@shared/graphql-client",
   "@shared/id-generator",
+  "@shared/sheet-sp-formater",
 ]);
 
 const basePath = "";

--- a/targets/frontend/package.json
+++ b/targets/frontend/package.json
@@ -17,6 +17,7 @@
     "@sentry/node": "^6.2.1",
     "@shared/graphql-client": "^1.0.0-alpha.1",
     "@shared/id-generator": "^1.0.0-alpha.1",
+    "@shared/sheet-sp-formater": "^1.0.0-alpha.1",
     "@socialgouv/cdtn-slugify": "^4.44.0",
     "@socialgouv/cdtn-sources": "^4.44.0",
     "@socialgouv/matomo-next": "^1.2.1",

--- a/targets/frontend/src/components/sheetSP/Form.js
+++ b/targets/frontend/src/components/sheetSP/Form.js
@@ -1,0 +1,317 @@
+/** @jsxImportSource theme-ui */
+import { ErrorMessage } from "@hookform/error-message";
+import { generateCdtnId } from "@shared/id-generator";
+import { format } from "@shared/sheet-sp-formater";
+import { SOURCES } from "@socialgouv/cdtn-sources";
+import Link from "next/link";
+import { useCallback, useMemo, useReducer, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { IoMdAdd, IoMdCheckmark, IoMdClose } from "react-icons/io";
+import { Button, IconButton } from "src/components/button";
+import { Box, Field, Flex, Label, NavLink } from "theme-ui";
+import { useMutation, useQuery } from "urql";
+
+// order is important, the higher priority comes first
+const sheetTypes = ["particuliers", "professionnels", "associations"];
+
+const insertDocumentsMutation = `
+mutation insert_documents($documents: [documents_insert_input!]!) {
+  documents: insert_documents(objects: $documents,  on_conflict: {
+    constraint: documents_pkey,
+    update_columns: [title, source, slug, text, document, is_available, is_searchable]
+  }) {
+   returning {cdtn_id}
+  }
+}
+`;
+
+const getSheetIdsQuery = `
+query sheetSP {
+  sheetIds: documents(where: {source: {_eq: "${SOURCES.SHEET_SP}"}}) {
+    initialId: initial_id
+  }
+}
+`;
+
+const SheetSPForm = () => {
+  const [result] = useQuery({
+    query: getSheetIdsQuery,
+  });
+  const { data: { sheetIds = [] } = {} } = result;
+  const existingSheetId = useMemo(
+    () => sheetIds.map(({ initialId }) => initialId),
+    [sheetIds]
+  );
+
+  const fieldArrayName = "sheetIds";
+  const {
+    control,
+    register,
+    handleSubmit,
+    errors,
+    setError,
+    reset: resetForm,
+    formState: { isDirty },
+  } = useForm({
+    defaultValues: {
+      [fieldArrayName]: [{ id: "" }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    keyName: "key",
+    name: fieldArrayName,
+  });
+
+  const hasError = Object.keys(errors).length > 0;
+
+  const [status, dispatch] = useReducer(reducer, []);
+  const [isProcessing, setProcessing] = useState(false);
+  const [displayStatus, setDisplayStatus] = useState(false);
+
+  const onSubmit = useCallback(
+    async ({ sheetIds }) => {
+      const providedIds = sheetIds.map(({ id }) => id.toUpperCase());
+      let hasError = false;
+
+      for (const [index, id] of providedIds.entries()) {
+        if (existingSheetId.includes(id)) {
+          setError(`${fieldArrayName}[${index}].id`, {
+            message: "Cette fiche est déjà présente !",
+            type: "'text",
+          });
+          hasError = true;
+        }
+        if (providedIds.filter((providedId) => providedId === id).length > 1) {
+          setError(`${fieldArrayName}[${index}].id`, {
+            message: "Vous essayez d’ajouter deux fois la même fiche !",
+            type: "'text",
+          });
+          hasError = true;
+          break;
+        }
+      }
+      if (hasError) return;
+
+      dispatch({
+        payload: providedIds.map((id) => ({
+          id,
+          status: "Recherche de la fiche...",
+        })),
+        type: "init",
+      });
+      setDisplayStatus(true);
+      setProcessing(true);
+      const sheetsToInsert = [];
+      // la c’est sequentiel, l’idéal ce serait d’utiliser forEach plutôt
+      // et de se debrouiller avec un state pour enregistrer les resultats
+      // sur un usecallback
+      for (const id of providedIds) {
+        // we could also check on jsdelivr CDN
+        const responses = await Promise.all(
+          sheetTypes.map((type) =>
+            fetch(
+              `https://unpkg.com/@socialgouv/fiches-vdd/data/${type}/${id}.json`
+            )
+          )
+        );
+        if (responses.every(({ status }) => status === 404)) {
+          dispatch({
+            payload: { id, status: "Fiche introuvable" },
+            type: "setStatus",
+          });
+        } else if (
+          responses.some(({ status }) => status !== 404 && status >= 400)
+        ) {
+          dispatch({
+            payload: {
+              id,
+              status:
+                "Une erreur est survenue pendant le chargement de la fiche.",
+            },
+            type: "setStatus",
+          });
+        } else {
+          let response;
+          // that’s why order is important
+          for (const res of responses) {
+            if (res.status !== 404) {
+              response = res;
+              break;
+            }
+          }
+          const rawSheet = await response.json();
+          console.log(rawSheet);
+          const formatedSheet = format(rawSheet, () => [], []);
+          sheetsToInsert.push(formatedSheet);
+          dispatch({
+            payload: { id, status: "En attente d’enregistrement" },
+            type: "setStatus",
+          });
+        }
+      }
+      for (const sheet of sheetsToInsert) {
+        // const toInsert = {
+        //   ...formatedFiche,
+        //   cdtn_id: generateCdtnId(`${source}${id}`),
+        //   initial_id: id,
+        //   is_available: true,
+        //   is_searchable: true,
+        //   meta_description: document.description || "",
+        // };
+        dispatch({
+          payload: { id: sheet.id, status: "Enregistrée" },
+          type: "setStatus",
+        });
+      }
+      setProcessing(false);
+    },
+    [existingSheetId, setError]
+  );
+
+  if (displayStatus) {
+    return (
+      <>
+        {isProcessing && <>Processing...</>}
+        <br />
+        {status.map(({ id, status }) => (
+          <div key={id}>
+            {id} : {status}
+          </div>
+        ))}
+        {!isProcessing && (
+          <Flex sx={{ alignItems: "center" }}>
+            <Link href={"/contenus?source=fiches_service_public"} passHref>
+              <NavLink mr="medium">Retour à la liste</NavLink>
+            </Link>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                resetForm();
+                dispatch({ type: "reset" });
+                setDisplayStatus(false);
+              }}
+            >
+              Retour au formulaire
+            </Button>
+          </Flex>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <>
+        <Label>{`Renseignez l’identifiant ${
+          fields.length > 1 ? "des" : "de la"
+        } fiche${fields.length > 1 ? "s" : ""} à ajouter`}</Label>
+        {fields.map((field, index) => (
+          <Box sx={{ my: "small" }} key={field.key}>
+            <Flex sx={{ alignItems: "center" }}>
+              <Field
+                sx={{ width: "10rem" }}
+                name={`${fieldArrayName}[${index}].id`}
+                defaultValue=""
+                ref={register({
+                  pattern: {
+                    message: `Seuls les identifiants de fiche sont acceptés (ils commencent
+                par un F, suivi de chiffres exclusivement).`,
+                    value: /^f\d{1,6}$/i,
+                  },
+                  required: "Vous n’avez pas renseigné l’identifiant",
+                })}
+              />{" "}
+              {fields.length > 1 && (
+                <IconButton
+                  sx={{ flex: "0 0 auto", ml: "xxsmall", padding: "small" }}
+                  type="button"
+                  variant="secondary"
+                  onClick={() => remove(index)}
+                >
+                  <IoMdClose
+                    sx={{
+                      flex: "1 0 auto",
+                      height: "iconMedium",
+                      width: "iconMedium",
+                    }}
+                  />
+                </IconButton>
+              )}
+              {index === fields.length - 1 && (
+                <Button
+                  size="small"
+                  variant="secondary"
+                  type="button"
+                  sx={{ flex: "0 0 auto", ml: "xxlarge" }}
+                  onClick={() => append({ id: "" })}
+                >
+                  <IoMdAdd
+                    sx={{
+                      height: "iconSmall",
+                      mr: "xxsmall",
+                      width: "iconSmall",
+                    }}
+                  />
+                  Renseigner une fiche supplémentaire
+                </Button>
+              )}
+            </Flex>
+            <ErrorMessage
+              errors={errors}
+              name={`${fieldArrayName}[${index}].id`}
+              render={({ message }) => <Box color="critical">{message}</Box>}
+            />
+          </Box>
+        ))}
+
+        <Flex mt="medium" sx={{ alignItems: "center" }}>
+          <Button variant="secondary" disabled={hasError || !isDirty}>
+            {isDirty && !hasError && (
+              <IoMdCheckmark
+                sx={{
+                  height: "iconSmall",
+                  mr: "xsmall",
+                  width: "iconSmall",
+                }}
+              />
+            )}
+            {`Ajouter ${fields.length > 1 ? "les" : "la"} fiche${
+              fields.length > 1 ? "s" : ""
+            }`}
+          </Button>
+          <Link href={"/contenus?source=fiches_service_public"} passHref>
+            <NavLink ml="medium">Retour à la liste</NavLink>
+          </Link>
+        </Flex>
+      </>
+    </form>
+  );
+};
+
+SheetSPForm.propTypes = {};
+
+export { SheetSPForm };
+
+function reducer(state, action) {
+  let idIndex;
+  switch (action.type) {
+    case "init":
+      return [...action.payload];
+    case "setStatus":
+      idIndex = state.findIndex(({ id }) => id === action.payload.id);
+      if (idIndex !== -1) {
+        return [
+          ...state.slice(0, idIndex),
+          { id: action.payload.id, status: action.payload.status },
+          ...state.slice(idIndex + 1),
+        ];
+      }
+      return state;
+    case "reset":
+      return [];
+    default:
+      throw new Error();
+  }
+}

--- a/targets/frontend/src/components/sheetSP/getContent.js
+++ b/targets/frontend/src/components/sheetSP/getContent.js
@@ -1,0 +1,17 @@
+import { request } from "src/lib/request";
+
+// order is important, the higher priority comes first
+const sheetTypes = ["particuliers", "professionnels", "associations"];
+
+export async function getContent(id) {
+  for (const type of sheetTypes) {
+    try {
+      return request(
+        `https://unpkg.com/@socialgouv/fiches-vdd@2.84.0/data/${type}/${id}.json`
+      );
+    } catch (error) {
+      console.log(`fail fetching fiche sp ${type}/${id}`);
+    }
+  }
+  return Promise.reject(`Impossible de récupérer la fiche sp ${id} `);
+}

--- a/targets/frontend/src/pages/contenus/create/[[...source]].js
+++ b/targets/frontend/src/pages/contenus/create/[[...source]].js
@@ -7,6 +7,7 @@ import { HighlightsForm } from "src/components/highlights/Form";
 import { Layout } from "src/components/layout/auth.layout";
 import { Stack } from "src/components/layout/Stack";
 import { PrequalifiedForm } from "src/components/prequalified/Form";
+import { SheetSPForm } from "src/components/sheetSP/Form";
 import { withCustomUrqlClient } from "src/hoc/CustomUrqlClient";
 import { withUserProvider } from "src/hoc/UserProvider";
 import { RELATIONS } from "src/lib/relations";
@@ -18,6 +19,7 @@ const CREATABLE_SOURCES = [
   SOURCES.THEMATIC_FILES,
   SOURCES.HIGHLIGHTS,
   SOURCES.PREQUALIFIED,
+  SOURCES.SHEET_SP,
 ];
 
 const createContentMutation = `
@@ -103,17 +105,20 @@ export function CreateDocumentPage() {
     case SOURCES.PREQUALIFIED:
       ContentForm = PrequalifiedForm;
       break;
+    case SOURCES.SHEET_SP:
+      ContentForm = SheetSPForm;
+      break;
     default:
       //eslint-disable-next-line react/display-name
       ContentForm = () => <span>Soon...</span>;
   }
 
   return (
-    <Layout title="Créer un contenu">
+    <Layout title="Ajouter un contenu">
       <Stack>
         <form>
           <Label htmlFor="source">
-            Quel type de document souhaitez vous créer&nbsp;?
+            Quel type de document souhaitez vous ajouter&nbsp;?
           </Label>
           <Select
             name="source"

--- a/targets/ingester/package.json
+++ b/targets/ingester/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@shared/graphql-client": "^1.0.0-alpha.1",
     "@shared/id-generator": "^1.0.0-alpha.1",
+    "@shared/sheet-sp-formater": "^1.0.0-alpha.1",
     "@socialgouv/cdtn-slugify": "^4.44.0",
     "@socialgouv/cdtn-sources": "^4.44.0",
     "get-uri": "^3.0.2",

--- a/targets/ingester/src/transform/fichesServicePublic/filter.js
+++ b/targets/ingester/src/transform/fichesServicePublic/filter.js
@@ -1,32 +1,38 @@
+import { client } from "@shared/graphql-client";
+import { SOURCES } from "@socialgouv/cdtn-sources";
+
 /**
- * Return a filtered set of FicheIndex
+ * Return a filtered set of FicheIndex based on the existing db set
  * @param {import("@socialgouv/fiches-vdd-types").FicheIndex[]} fiches
  */
-export function filter(fiches) {
+export async function filter(fiches) {
+  const result = await client
+    .query(
+      `
+      query sheetSP_documents {
+        documents(where: {source: {_eq: "${SOURCES.SHEET_SP}"}}) {
+          initialId: initial_id
+        }
+      }
+    `
+    )
+    .toPromise();
+
+  if (result.error) {
+    console.error(result.error);
+    throw new Error(`error while retrieving current list of sheet SP`);
+  }
+
+  const currentFichesId = result.data.documents.map(
+    /**
+     * @param {{initialId:string}} document
+     * @returns {string}
+     */
+    ({ initialId }) => initialId
+  );
+
   const filteredFiches = fiches.filter((fiche) => {
-    const arianeIds = fiche.breadcrumbs.map((item) => item.id);
-    if (!fiche.id.startsWith("F")) {
-      return false;
-    }
-    /**  @param {string} id */
-    const matchFilDAriane = (id) => arianeIds.includes(id);
-
-    if (excludeFicheId.some(matchFilDAriane)) {
-      return false;
-    }
-    if (excludeDossierId.some(matchFilDAriane)) {
-      // Il existe des fiches que l'on souhaite garder, alors que
-      // l'on ne souhaite pas garder son dossier parent
-      return includeFicheId.some(matchFilDAriane);
-    }
-
-    const includeList = includeThemeId.concat(includeDossierId, includeFicheId);
-    if (includeList.some(matchFilDAriane)) {
-      return true;
-    }
-
-    // Par défaut, on exclue
-    return false;
+    currentFichesId.includes(fiche.id);
   });
   const particuliers = filteredFiches.filter(
     ({ type }) => type === "particuliers"
@@ -48,142 +54,3 @@ export function filter(fiches) {
 
   return particuliers.concat(professionnels, associations);
 }
-
-// Liste fournie par @jrduscher
-const excludeDossierId = [
-  "N500",
-  "N511",
-  "N505",
-  "N31057",
-  "N19978",
-  "N186",
-  "N431",
-  "N512",
-  "N503",
-  "N102",
-  "N20276",
-  "N515",
-  "N379",
-];
-const excludeFicheId = [
-  "F1234",
-  "F3059",
-  "F10027",
-  "F12416",
-  "F13375",
-  "F20314",
-  "F20678",
-  "F22290",
-  "F22295",
-  "F22316",
-  "F22327",
-  "F22335",
-  "F22352",
-  "F22354",
-  "F22356",
-  "F22358",
-  "F22359",
-  "F22424",
-  "F22532",
-  "F22553",
-  "F22726",
-  "F23369",
-  "F23459",
-  "F23460",
-  "F23507",
-  "F23670",
-  "F23744",
-  "F23756",
-  "F23891",
-  "F23992",
-  "F23994",
-  "F23997",
-  "F24005",
-  "F24013",
-  "F31195",
-  "F31204",
-  "F31233",
-  "F31263",
-  "F31406",
-  "F31409",
-  "F31422",
-  "F31427",
-  "F31479",
-  "F31670",
-  "F31712",
-  "F31713",
-  "F31837",
-  "F31926",
-  "F32090",
-  "F32095",
-  "F32234",
-  "F32258",
-  "F32307",
-  "F32308",
-  "F32581",
-  "F32703",
-  "F32965",
-  "F33843",
-  "F34629",
-  "F34631",
-  "F34633",
-  "F34900",
-];
-const includeDossierId = [
-  "N20286",
-  "N31477",
-  "N107",
-  "N31143",
-  "N16594",
-  "N24267",
-  "N31775",
-  "N22781",
-  "N10779",
-  "N31391",
-  "N31392",
-];
-const includeThemeId = [
-  "N19806", // particulier / travail
-];
-const includeFicheId = [
-  "F92",
-  "F153",
-  "F174",
-  "F1043",
-  "F1190",
-  "F1226",
-  "F1234",
-  "F1642",
-  "F1691",
-  "F1928",
-  "F2064",
-  "F2140",
-  "F2141",
-  "F2142",
-  "F2309",
-  "F2354",
-  "F2517",
-  "F2642",
-  "F2742",
-  "F10029",
-  "F10041",
-  "F12382",
-  "F14809",
-  "F14860",
-  "F14868",
-  "F15132",
-  "F15813",
-  "F19087",
-  "F21000",
-  "F22606",
-  "F23106",
-  "F23425",
-  "F23633",
-  "F31982",
-  "F32329",
-  "F32709",
-  "F33050",
-  "F34059",
-  "F34705",
-  "F34902",
-];

--- a/targets/ingester/src/transform/fichesServicePublic/index.js
+++ b/targets/ingester/src/transform/fichesServicePublic/index.js
@@ -1,9 +1,9 @@
-import slugify from "@socialgouv/cdtn-slugify";
+import { format } from "@shared/sheet-sp-formater";
 
 import { getJson } from "../../lib/getJson.js";
 import { referenceResolver } from "../../lib/referenceResolver";
 import { filter } from "./filter.js";
-import { format } from "./format.js";
+
 // Extract external content url from Content tag markdown
 /**
  *
@@ -38,7 +38,7 @@ export default async function getFichesServicePublic(pkgName) {
 
   const resolveCdtReference = referenceResolver(cdt);
 
-  const listFicheVdd = filter(ficheVddIndex);
+  const listFicheVdd = await filter(ficheVddIndex);
 
   const fichesIdFromContrib = contributions.flatMap(({ answers }) => {
     const url = extractMdxContentUrl(answers.generic.markdown);
@@ -63,7 +63,6 @@ export default async function getFichesServicePublic(pkgName) {
     fiches.push({
       ...ficheSp,
       is_searchable: !fichesIdFromContrib.includes(ficheSp.id),
-      slug: slugify(ficheSp.title),
     });
   }
 


### PR DESCRIPTION
Related to https://github.com/SocialGouv/cdtn-admin/issues/263

Reste à faire (beaucoup de choses !):
- Rendre l’ui plus sympa avec des loaders, des icones etc.
- Lancer toutes les requêtes en parallèle ? 
- Découper le fichier un peu gros ?
- Enregistrer les fiches en base et trigger l’update d’elastic
- Corriger mes bêtises
- tester le nouveau filtre de l’ingester