### PR TITLE
fix(alerts): export contributions alerts only in prod deployement

### DIFF
--- a/.k8s/__tests__/__snapshots__/generate-prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/generate-prod.ts.snap
@@ -9,6 +9,7 @@ metadata:
 data:
   NODE_ENV: production
   HASURA_GRAPHQL_ENDPOINT: http://hasura/v1/graphql
+  CONTRIBUTIONS_ENPOINT: https://contributions-api.codedutravail.fabrique.social.gouv.fr
 ---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret

--- a/.k8s/environments/prod/alert.configmap.yaml
+++ b/.k8s/environments/prod/alert.configmap.yaml
@@ -5,3 +5,4 @@ metadata:
 data:
   NODE_ENV: "production"
   HASURA_GRAPHQL_ENDPOINT: "http://hasura/v1/graphql"
+  CONTRIBUTIONS_ENPOINT: "https://contributions-api.codedutravail.fabrique.social.gouv.fr"

--- a/targets/alert-cli/src/__test__/exportContributionAlerts.test.js
+++ b/targets/alert-cli/src/__test__/exportContributionAlerts.test.js
@@ -1,15 +1,21 @@
 /* eslint-disable */
 import fetch from "node-fetch";
 
-import {
-  contribApiUrl,
-  exportContributionAlerts,
-} from "../exportContributionAlerts";
+import { exportContributionAlerts } from "../exportContributionAlerts";
 
 jest.mock("node-fetch");
 
+afterEach(() => {
+  delete process.env.CONTRIBUTIONS_ENDPOINT;
+});
+
 describe("exportContributionAlerts", () => {
+  it("should skip exportContributionAlerts", async () => {
+    await exportContributionAlerts("repositoryTest", "v0.0.0", {});
+    expect(fetch).not.toHaveBeenCalled();
+  });
   it("should export changes to contributions API", async () => {
+    process.env.CONTRIBUTIONS_ENDPOINT = "contributions.url";
     const changes = /** @type {alerts.AlertChanges[]}*/ ([
       {
         added: [
@@ -105,7 +111,7 @@ describe("exportContributionAlerts", () => {
     });
     await exportContributionAlerts("repositoryTest", "v0.0.0", changes);
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(contribApiUrl, {
+    expect(fetch).toHaveBeenCalledWith("contributions.url/alerts", {
       body: JSON.stringify([
         {
           answer_id: "cdtnId-contrib-1",

--- a/targets/alert-cli/src/exportContributionAlerts.js
+++ b/targets/alert-cli/src/exportContributionAlerts.js
@@ -1,8 +1,5 @@
 import fetch from "node-fetch";
 
-export const contribApiUrl =
-  "https://contributions-api.codedutravail.fabrique.social.gouv.fr/alerts";
-
 /**
  * @param {string} repository
  * @param {alerts.GitTagData} lastTag
@@ -13,6 +10,12 @@ export async function exportContributionAlerts(
   lastTag,
   alertChanges
 ) {
+  if (!process.env.CONTRIBUTIONS_ENDPOINT) {
+    console.info(
+      "[exportContributionAlerts] skip sending alert to conributions endpoint"
+    );
+    return;
+  }
   const dilaAlertChanges = /** @type {alerts.DilaAlertChanges[]} */ (alertChanges.filter(
     (change) => change.type === "dila"
   ));
@@ -51,6 +54,8 @@ export async function exportContributionAlerts(
     return;
   }
 
+  const contribApiUrl = `${process.env.CONTRIBUTIONS_ENDPOINT}/alerts`;
+
   fetch(contribApiUrl, {
     body: JSON.stringify(contributions),
     headers: {
@@ -69,6 +74,7 @@ export async function exportContributionAlerts(
       console.info(
         `Sending ${contributions.length} alert(s) from ${repository} to ${contribApiUrl}`
       );
+      console.debug(JSON.stringify(contributions));
     })
     .catch((err) => {
       console.error(


### PR DESCRIPTION
limit runing exportContributionAlerts to production env

fix #399 