### PR TITLE
feat(ingester-es): use only major as elasticsearch index prefix

### DIFF
--- a/.k8s/__tests__/__snapshots__/generate-prod-ingester-elasticsearch.ts.snap
+++ b/.k8s/__tests__/__snapshots__/generate-prod-ingester-elasticsearch.ts.snap
@@ -119,7 +119,7 @@ spec:
                 name: ingester-elasticsearch-to-preprod
           env:
             - name: ES_INDEX_PREFIX
-              value: cdtn-preprod-v1.2.3
+              value: cdtn-preprod-v1
       restartPolicy: Never
   ttlSecondsAfterFinished: 86400
 "
@@ -245,7 +245,7 @@ spec:
                 name: ingester-elasticsearch-to-prod
           env:
             - name: ES_INDEX_PREFIX
-              value: cdtn-prod-v1.2.3
+              value: cdtn-prod-v1
       restartPolicy: Never
   ttlSecondsAfterFinished: 86400
 "

--- a/.k8s/utils/ES_INDEX_PREFIX.ts
+++ b/.k8s/utils/ES_INDEX_PREFIX.ts
@@ -7,11 +7,16 @@ if (process.env.CI_COMMIT_REF_SLUG === "master") {
 }
 
 const target = process.env.INGESTER_ELASTICSEARCH_TARGET;
-
-if (target === "preprod") {
-  ES_INDEX_PREFIX = `cdtn-preprod-${process.env.CI_COMMIT_TAG}`;
-} else if (target === "prod") {
-  ES_INDEX_PREFIX = `cdtn-prod-${process.env.CI_COMMIT_TAG}`;
+if (process.env.CI_COMMIT_TAG) {
+  const matchVersion = process.env.CI_COMMIT_TAG.match(/^(v\d)+\.(\d+)\.(\d+)/);
+  if (matchVersion) {
+    const [, major] = matchVersion;
+    if (target === "preprod") {
+      ES_INDEX_PREFIX = `cdtn-preprod-${major}`;
+    } else if (target === "prod") {
+      ES_INDEX_PREFIX = `cdtn-prod-${major}`;
+    }
+  }
 }
 
 export { ES_INDEX_PREFIX };


### PR DESCRIPTION
I've updated the versionning policy to avoid coupling cdtn release to cdtn-admin release
With the current policy, each time we made a release on cdtn-admin, a new index is created with the version (ex: v1.0.1) in the index name.  the previous index used by cdtn hasn't been updated and if we want to swithc on that index, we will need to made a release / production to retrieve the cdtn-admin version.

using only major version allow us to still update the index, without the need to release / production on cdtn (or only for breaking change)  

what do you think ?