### PR TITLE
revert: "feat(gitlab): add manual preprod update"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -250,30 +250,3 @@ Export storage to prod:
     DESTINATION_SERVER: "prod"
     # kosko options
     KOSKO_GENERATE_ARGS: --env prod restore/containers
-
-Restore preprod data:
-  needs: []
-  stage: .post
-  extends:
-    - .base_deploy_kosko_stage
-  cache:
-    key:
-      files:
-        - .k8s/yarn.lock
-      prefix: k8s
-    paths:
-      - .cache
-      - .k8s/node_modules
-  environment:
-    name: ${AUTO_DEVOPS_PROD_ENVIRONMENT_NAME}
-  rules:
-    - if: "$PRODUCTION || $TRIGGER"
-      when: never
-    - if: "$CI_COMMIT_TAG"
-      when: manual
-      allow_failure: true
-  variables:
-    # Extract from https://github.com/SocialGouv/gitlab-ci-yml/blob/v20.7.14/base_autodevops.yml#L313
-    KUBE_NAMESPACE: ${CI_PROJECT_NAME}
-    # kosko options
-    KOSKO_GENERATE_ARGS: --env prod jobs/restore

--- a/.k8s/components/hasura.ts
+++ b/.k8s/components/hasura.ts
@@ -8,7 +8,7 @@ import { GITLAB_LIKE_ENVIRONMENT_SLUG } from "../utils/GITLAB_LIKE_ENVIRONMENT_S
 
 const manifests = create({
   config: {
-    image: getHarborImagePath({ name: "cdtn-admin-hasura" }),
+    image: getHarborImagePath({name:'cdtn-admin-hasura'}),
     container: {
       resources: {
         limits: {


### PR DESCRIPTION
Reverts SocialGouv/cdtn-admin#443

in fact, since containers are removed after one day, we could re-use retore data job and run once a day to reset preprod db with the previous day backup 