### PR TITLE
fix(ci): fix release node image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,7 @@ Stop review:
 #
 
 Release:
+  image: node:16.10.0-stretch
   extends:
     - .autodevops_release
   allow_failure: true


### PR DESCRIPTION
`error @npmcli/arborist@3.0.0: The engine "node" is incompatible with this module. Expected version "^12.13.0 || ^14.15.0 || >=16". Got "15.14.0"`