### PR TITLE
feat(ingester): keep existing highlight on agreements

### DIFF
--- a/targets/ingester/src/transform/agreements/agreementsWithHighlight.ts
+++ b/targets/ingester/src/transform/agreements/agreementsWithHighlight.ts
@@ -1,0 +1,49 @@
+import { client } from "@shared/graphql-client";
+
+const getAgreementsWithHighlightQuery = `
+query get_agreements_with_highlight {
+  documents(where: {source: {_eq: "conventions_collectives"}, document: {_has_key: "highlight"}}) {
+    num: document(path: "$.num")
+    highlight: document(path: "$.highlight")
+  }
+}
+`;
+
+type AgreementHighlight = {
+  title?: string;
+  content?: string;
+  searchInfo?: string;
+};
+
+type AgreementWithHighlight = {
+  num: number;
+  highlight: AgreementHighlight;
+};
+
+type AgreementsResult = {
+  documents: AgreementWithHighlight[];
+};
+
+const getAgreementsWithHighlight = async (): Promise<
+  Partial<Record<number, AgreementHighlight>>
+> => {
+  const result = await client
+    .query<AgreementsResult>(getAgreementsWithHighlightQuery)
+    .toPromise();
+
+  if (result.error) {
+    throw new Error(`error while retrieving current agreements data`);
+  }
+  if (result.data !== undefined) {
+    return result.data.documents.reduce(
+      (acc: Record<number, AgreementHighlight>, curr) => {
+        acc[curr.num] = curr.highlight;
+        return acc;
+      },
+      {}
+    );
+  }
+  return {};
+};
+
+export default getAgreementsWithHighlight;

--- a/targets/ingester/src/transform/agreements/index.ts
+++ b/targets/ingester/src/transform/agreements/index.ts
@@ -8,6 +8,7 @@ import html from "remark-html";
 import type { AgreementPage } from "../../index.js";
 import { formatIdcc } from "../../lib/formatIdcc.js";
 import { getJson } from "../../lib/getJson.js";
+import getAgreementsWithHighlight from "./agreementsWithHighlight";
 import { getAllKaliBlocks } from "./getKaliBlock.js";
 import { getKaliArticlesByTheme } from "./kaliArticleBytheme.js";
 
@@ -39,12 +40,17 @@ export default async function getAgreementDocuments(pkgName: string) {
     };
   });
 
+  const agreementsWithHighlight = await getAgreementsWithHighlight();
+
   const agreementPages: AgreementPage[] = [];
 
   for (const agreement of agreements) {
     const agreementTree = await getJson<Agreement>(
       `@socialgouv/kali-data/data/${agreement.id}.json`
     );
+
+    const highlight = agreementsWithHighlight[agreement.num];
+
     agreementPages.push({
       ...getCCNInfo(agreement),
       answers: getContributionAnswers(contributionsWithSlug, agreement.num),
@@ -55,6 +61,7 @@ export default async function getAgreementDocuments(pkgName: string) {
       is_searchable: true,
       source: SOURCES.CCN,
       synonymes: agreement.synonymes,
+      ...(highlight ? { highlight } : {}),
     });
   }
   const sorter = createSorter(({ num }: AgreementPage) => num);


### PR DESCRIPTION
Avoid overwriting the `highlight` field in the agreements document when new data are available.

co-author @maxgfr 