### PR TITLE
fix(alerting): support agreement removed

### DIFF
--- a/targets/alert-cli/src/diff/dila-data.ts
+++ b/targets/alert-cli/src/diff/dila-data.ts
@@ -105,12 +105,16 @@ export async function processDilaDataDiff(
             { file: fileChange.file }
           );
         }
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const data = fileChange.current.data
+          ? fileChange.current.data
+          : fileChange.previous.data;
         return {
           ...changes,
           documents,
           file: fileChange.file,
-          id: fileChange.current.data.id,
-          title: fileChange.current.data.title,
+          id: data.id,
+          title: data.title,
         };
       } else {
         const changes = compareTree<Agreement>(fileChange);
@@ -121,13 +125,17 @@ export async function processDilaDataDiff(
             { file: fileChange.file }
           );
         }
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const data = fileChange.current.data
+          ? fileChange.current.data
+          : fileChange.previous.data;
         return {
           ...changes,
           documents,
           file: fileChange.file,
-          id: fileChange.current.data.id,
-          num: fileChange.current.data.num,
-          title: fileChange.current.data.shortTitle,
+          id: data.id,
+          num: data.num,
+          title: data.shortTitle,
         };
       }
     })
@@ -278,6 +286,7 @@ function removedNodeAdapter(node: WithParent<DilaNode>): DilaRemovedNode {
       node.type === "article" ? node.data.num ?? "Article" : node.data.title,
   };
 }
+
 const createModifiedAdapter =
   (modified: WithParent<DilaNode>[]) =>
   (node: WithParent<DilaNode>): DilaModifiedNode => {

--- a/targets/frontend/src/components/changes/ChangeGroup.tsx
+++ b/targets/frontend/src/components/changes/ChangeGroup.tsx
@@ -45,6 +45,7 @@ type ChangesProps = {
 type DilaChangesProps = {
   changes: DilaAlertChanges;
 };
+
 export function AlertRelatedDocuments({
   changes,
 }: DilaChangesProps): JSX.Element {
@@ -103,6 +104,7 @@ export function DilaRelatedDocuments({
 type FicheRelatedDocumentsProps = {
   doc: DocumentInfoWithCdtnRef;
 };
+
 export function FicheRelatedDocuments({
   doc,
 }: FicheRelatedDocumentsProps): JSX.Element {
@@ -341,6 +343,10 @@ const DilaLink: React.FC<DilaLinkProps> = ({ info, children }) => {
   const { parents, id, title } = info;
   let url = "";
   const baseUrl = "https://legifrance.gouv.fr";
+  // Sometimes, there is no id on the diff. So we can't create an URL.
+  if (!id) {
+    return <>{children && title}</>;
+  }
   if (id.startsWith("LEGI")) {
     if (/ARTI/.test(id)) {
       // article d'un code


### PR DESCRIPTION
Correctif rapide sur l'alerting. 

L'alerting n'aime pas quand on a des suppressions/ajouts. Pour le moment, j'ai triché car je bascule entre le previous et le current pour récupérer des informations mais du coup les types ne sont pas bon. Il faut revoir le typescript.

La prochaine étape est d'ajouter des TU pour reproduire les cas et ensuite de refactorer le code pour supporter les différents cas.

fixes #687 

