### PR TITLE
fix(ingester): parents is not default exported anymore

### DIFF
--- a/targets/ingester/@types/unist-util-parents.d.ts
+++ b/targets/ingester/@types/unist-util-parents.d.ts
@@ -4,11 +4,6 @@ declare module "unist-util-parents" {
     children: NodeWithParent<Child>;
   };
 
-  export type RootNodeWithParent<T> = T & {
-    parent: null;
-    children: NodeWithParent<T>;
-  };
-
   export type NodeWithParentChild<Parent, Child> = Child & {
     parent: NodeWithParent<Parent>;
     children: NodeWithParent<Child>[];
@@ -19,5 +14,5 @@ declare module "unist-util-parents" {
     children: NodeWithParent<T>[];
   };
 
-  export default function parent<R, C>(node: R): RootNodeWithParentChild<R, C>;
+  export function parents<R, C>(node: R): RootNodeWithParentChild<R, C>;
 }

--- a/targets/ingester/src/transform/agreements/kaliArticleBytheme.ts
+++ b/targets/ingester/src/transform/agreements/kaliArticleBytheme.ts
@@ -6,7 +6,7 @@ import type {
 } from "@socialgouv/kali-data-types";
 import find from "unist-util-find";
 import type { NodeWithParentChild } from "unist-util-parents";
-import parents from "unist-util-parents";
+import { parents } from "unist-util-parents";
 
 import { createSorter } from ".";
 


### PR DESCRIPTION
La librairie a changé en version 2.0.0
Le type étant en dur dans notre code, cela ne l'a pas détecté. Il faudrait utiliser les types des libs unist mais je n'ai pas compris grand chose à leurs types...