### PR TITLE
fix(contribution): add trigger to update the updated_at field

### DIFF
--- a/targets/hasura/migrations/1654608190000_trigger_to_updated_at/down.sql
+++ b/targets/hasura/migrations/1654608190000_trigger_to_updated_at/down.sql
@@ -1,0 +1,6 @@
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.agreements;
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.answers;
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.answers_comments;
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.answers_references;
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.locations;
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.questions;

--- a/targets/hasura/migrations/1654608190000_trigger_to_updated_at/up.sql
+++ b/targets/hasura/migrations/1654608190000_trigger_to_updated_at/up.sql
@@ -1,0 +1,12 @@
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.agreements;
+CREATE TRIGGER update_updated_at BEFORE UPDATE ON contrib.agreements FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.answers;
+CREATE TRIGGER update_updated_at BEFORE UPDATE ON contrib.answers FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.answers_comments;
+CREATE TRIGGER update_updated_at BEFORE UPDATE ON contrib.answers_comments FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.answers_references;
+CREATE TRIGGER update_updated_at BEFORE UPDATE ON contrib.answers_references FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.locations;
+CREATE TRIGGER update_updated_at BEFORE UPDATE ON contrib.locations FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+DROP TRIGGER IF EXISTS update_updated_at ON contrib.questions;
+CREATE TRIGGER update_updated_at BEFORE UPDATE ON contrib.questions FOR EACH ROW EXECUTE PROCEDURE set_updated_at();


### PR DESCRIPTION
Il manquait le trigger pour mettre à jour le champ updated_at dans la BDD lorsque l'on édite une donnée.