### PR TITLE
fix(permissions): ajout des permissions sur les tables dans le schéma v1

### DIFF
--- a/targets/hasura/metadata/databases/default/tables/v1_fiches_travail_data_alerts.yaml
+++ b/targets/hasura/metadata/databases/default/tables/v1_fiches_travail_data_alerts.yaml
@@ -1,3 +1,16 @@
 table:
   name: fiches_travail_data_alerts
   schema: v1
+select_permissions:
+  - role: super
+    permission:
+      columns:
+        - info
+        - ref
+        - repository
+        - status
+        - created_at
+        - updated_at
+        - id
+      filter: {}
+      allow_aggregations: true

--- a/targets/hasura/metadata/databases/default/tables/v1_fiches_vdd_alerts.yaml
+++ b/targets/hasura/metadata/databases/default/tables/v1_fiches_vdd_alerts.yaml
@@ -1,3 +1,16 @@
 table:
   name: fiches_vdd_alerts
   schema: v1
+select_permissions:
+  - role: super
+    permission:
+      columns:
+        - info
+        - ref
+        - repository
+        - status
+        - created_at
+        - updated_at
+        - id
+      filter: {}
+      allow_aggregations: true

--- a/targets/hasura/metadata/databases/default/tables/v1_kali_data_alerts.yaml
+++ b/targets/hasura/metadata/databases/default/tables/v1_kali_data_alerts.yaml
@@ -1,3 +1,16 @@
 table:
   name: kali_data_alerts
   schema: v1
+select_permissions:
+  - role: super
+    permission:
+      columns:
+        - info
+        - ref
+        - repository
+        - status
+        - created_at
+        - updated_at
+        - id
+      filter: {}
+      allow_aggregations: true

--- a/targets/hasura/metadata/databases/default/tables/v1_legi_data_alerts.yaml
+++ b/targets/hasura/metadata/databases/default/tables/v1_legi_data_alerts.yaml
@@ -1,3 +1,16 @@
 table:
   name: legi_data_alerts
   schema: v1
+select_permissions:
+  - role: super
+    permission:
+      columns:
+        - id
+        - info
+        - status
+        - repository
+        - ref
+        - created_at
+        - updated_at
+      filter: {}
+      allow_aggregations: true


### PR DESCRIPTION
Corrections de deux bugs :

 * Problème sur l'upload des fichiers (en fait le premier stream étant lu pour détecté du code malveillant, le code d'azure pour l'upload ne marchait plus). On pense que c'est du à une montée de version de NextJS. Du coup on duplique les streams pour éviter d'altérer le stream d'upload.
 
  * Problème sur les permissions empêchant d'ajouter des fiches sp sur l'admin