### PR TITLE
fix(ci): deprecated `set-output` fixed

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,7 +18,7 @@ jobs:
           node-version-file: ".node-version"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.kube-workflow/values.yaml
+++ b/.kube-workflow/values.yaml
@@ -50,8 +50,8 @@ app-export:
       cpu: '2000m'
       memory: 2Gi
     requests:
-      cpu: '2000m'
-      memory: 1Gi
+      cpu: '5m'
+      memory: 128Mi
 
 hasura:
   imagePackage: cdtn-admin-hasura

--- a/.kube-workflow/values.yaml
+++ b/.kube-workflow/values.yaml
@@ -14,7 +14,7 @@ app-www:
       cpu: "1000m"
       memory: "560Mi"
     requests:
-      cpu: "5m"
+      cpu: "500m"
       memory: "128Mi"
 
 app-contributions:
@@ -31,7 +31,7 @@ app-contributions:
       cpu: "1000m"
       memory: "560Mi"
     requests:
-      cpu: "5m"
+      cpu: "500m"
       memory: "128Mi"
 
 app-export:
@@ -50,7 +50,7 @@ app-export:
       cpu: '2000m'
       memory: 2Gi
     requests:
-      cpu: '5m'
+      cpu: '500m'
       memory: 128Mi
 
 hasura:


### PR DESCRIPTION
cf : [github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)