### PR TITLE
fix: page service public vide

### DIFF
--- a/targets/ingester/src/cli.ts
+++ b/targets/ingester/src/cli.ts
@@ -171,19 +171,24 @@ async function getLastIngestedVersion(pkgName: string) {
 async function insertDocuments(docs: ingester.CdtnDocument[]) {
   const result = await client
     .mutation<InsertdocumentResult>(insertDocumentsMutation, {
-      documents: docs.map(
-        ({ id, text, title, slug, is_searchable, source, ...document }) => ({
-          cdtn_id: generateCdtnId(`${source}${id}`),
-          document,
-          initial_id: id,
-          is_available: true,
-          is_searchable,
-          meta_description: document.description || "",
-          slug,
-          source,
-          text,
-          title,
-        })
+      documents: docs.flatMap(
+        ({ id, text, title, slug, is_searchable, source, ...document }) =>
+          text.trim()
+            ? [
+                {
+                  cdtn_id: generateCdtnId(`${source}${id}`),
+                  document,
+                  initial_id: id,
+                  is_available: true,
+                  is_searchable,
+                  meta_description: document.description || "",
+                  slug,
+                  source,
+                  text,
+                  title,
+                },
+              ]
+            : []
       ),
     })
     .toPromise();


### PR DESCRIPTION
fix bug: https://code.travail.gouv.fr/fiche-service-public/licenciement-economique-entretien-prealable

Requête SQL à passer:
```
delete from documents d 
where TRIM(d.text) = '' and is_published = true and source = 'fiches_service_public'
```