### PR TITLE
fix(fiches-sp): bug dans la suppression des fiches SP

### DIFF
--- a/targets/frontend/src/components/fiches-sp/fichesSpContainer.js
+++ b/targets/frontend/src/components/fiches-sp/fichesSpContainer.js
@@ -17,7 +17,7 @@ export function FichesServicePublicContainer() {
     []
   );
 
-  const [, setSelectedItems] = useContext(SelectionContext);
+  const { setSelectedItems } = useContext(SelectionContext);
 
   const itemsPerPage = 25;
 

--- a/targets/frontend/src/components/fiches-sp/list.js
+++ b/targets/frontend/src/components/fiches-sp/list.js
@@ -24,7 +24,7 @@ export function ServicPublicList({ items }) {
 }
 
 function ServicePublicItemRow({ item }) {
-  const [selectedItems, setSelectedItems] = useContext(SelectionContext);
+  const { selectedItems, setSelectedItems } = useContext(SelectionContext);
 
   function updateSelection(event) {
     if (event.target.checked) {

--- a/targets/frontend/src/components/fiches-sp/selectActions.js
+++ b/targets/frontend/src/components/fiches-sp/selectActions.js
@@ -8,7 +8,7 @@ import { Inline } from "../layout/Inline";
 import { Stack } from "../layout/Stack";
 
 export function Actions({ onDelete }) {
-  const [selectedItems] = useContext(SelectionContext);
+  const { selectedItems } = useContext(SelectionContext);
   const [showDeleteDialog, setDeleteDialogVisible] = useState(false);
   const openDeleteDialog = () => setDeleteDialogVisible(true);
   const closeDeleteDialog = () => setDeleteDialogVisible(false);

--- a/targets/frontend/src/pages/contenus/fiches-sp.tsx
+++ b/targets/frontend/src/pages/contenus/fiches-sp.tsx
@@ -6,19 +6,27 @@ import { Layout } from "src/components/layout/auth.layout";
 import { withCustomUrqlClient } from "src/hoc/CustomUrqlClient";
 import { withUserProvider } from "src/hoc/UserProvider";
 
-export const SelectionContext = createContext([
-  [],
-  () => {
+export type SelectionContextInterface = {
+  selectedItems: string[];
+  setSelectedItems: (selected: string[]) => void;
+};
+
+export const SelectionContext = createContext<SelectionContextInterface>({
+  selectedItems: [],
+  setSelectedItems: () => {
     return;
   },
-]);
+});
 
 function FichesServicePublicPage() {
-  const [selectedItems, setSelectedItems] = useState([]);
+  const [selectedItems, setSelectedItems] = useState<string[]>([]);
 
   return (
     <SelectionContext.Provider
-      value={[selectedItems, (...args) => setSelectedItems(args)]}
+      value={{
+        selectedItems,
+        setSelectedItems,
+      }}
     >
       <Layout title="Fiches service-public.fr">
         <FichesServicePublicContainer />


### PR DESCRIPTION
Correctif sur la page fiches-sp de l'admin. 

Il est impossible de supprimer des fiches SP. Lors de la sélection, on concat des tableaux dans des tableaux, ce qui donne la requête GraphQL:

```json
{"query":"mutation deleteServicePublicIds($ids: [String!] = []) {\n  delete_service_public_contents(where: {id: {_in: $ids}}) {\n    affected_rows\n    returning {\n      id\n      __typename\n    }\n    __typename\n  }\n}","operationName":"deleteServicePublicIds","variables":{"ids":[["F35309"]]}}
```

Alors que l'on attend un tableau de string.

J'en ai profité pour ajouter un type sur le context et changé le contenu du context par un objet et non un tableau (plus facile à typer et valider le type avec TS).