### PR TITLE
fix: ne plus envoyer le secret_token depuis le frontend

### DIFF
--- a/targets/frontend/src/lib/emails/activateAccount.ts
+++ b/targets/frontend/src/lib/emails/activateAccount.ts
@@ -3,7 +3,7 @@ import sendmail from "./sendmail";
 const BASE_URL =
   process.env.FRONTEND_HOST || `http://localhost:${process.env.PORT}`;
 
-export function sendActivateAccountEmail(email, secret_token) {
+export function sendActivateAccountEmail(email: string, secret_token: string) {
   const subject = "Activation de votre compte";
   const activateUrl = `${BASE_URL}/change_password?token=${secret_token}&activate=1`; // todo: dynamic hostname
   const text = `Bonjour,
@@ -13,7 +13,7 @@ export function sendActivateAccountEmail(email, secret_token) {
   L'equipe veille CDTN
   `;
 
-  var mailOptions = {
+  const mailOptions = {
     from: process.env.ACCOUNT_MAIL_SENDER,
     subject,
     text,

--- a/targets/frontend/src/lib/emails/getAccountSecretToken.ts
+++ b/targets/frontend/src/lib/emails/getAccountSecretToken.ts
@@ -1,0 +1,32 @@
+import { client as gqlClient } from "@shared/graphql-client";
+import { gql } from "@urql/core";
+
+const getUserSecretTokenRequest = gql`
+  query GetUserSecretToken($email: citext!) {
+    auth_users(
+      where: {
+        email: { _eq: $email }
+        deleted: { _eq: false }
+        active: { _eq: false }
+      }
+    ) {
+      secret_token
+    }
+  }
+`;
+
+export async function getUserSecretToken(email: string) {
+  const result = await gqlClient
+    .query<{ auth_users: [{ secret_token: string }] }, { email: string }>(
+      getUserSecretTokenRequest,
+      {
+        email,
+      }
+    )
+    .toPromise();
+  if (result.error) {
+    console.error("[getUserSecretToken]", result.error);
+    throw result.error;
+  }
+  return result?.data?.auth_users?.[0]?.secret_token!!;
+}

--- a/targets/frontend/src/pages/user/new.js
+++ b/targets/frontend/src/pages/user/new.js
@@ -19,8 +19,8 @@ mutation registerUser($user: auth_users_insert_input! ) {
 `;
 
 const emailAccountMutation = `
-mutation email($email: citext!, $secret_token: uuid!) {
-	email_account_activation(email: $email, secret_token:$secret_token)
+mutation email($email: citext!) {
+	email_account_activation(email: $email)
 }
 `;
 
@@ -35,6 +35,7 @@ function prepareMutationData(input) {
     },
   };
 }
+
 export function UserPage() {
   const router = useRouter();
   const [result, registerUser] = useMutation(registerUserMutation);
@@ -45,8 +46,8 @@ export function UserPage() {
     registerUser(prepareMutationData(data)).then((result) => {
       if (!result.error) {
         router.push("/users");
-        const { email, secret_token } = result.data.user;
-        emailAccount({ email, secret_token });
+        const { email } = result.data.user;
+        emailAccount({ email });
       }
     });
   }

--- a/targets/hasura/metadata/actions.graphql
+++ b/targets/hasura/metadata/actions.graphql
@@ -1,7 +1,6 @@
 type Mutation {
   email_account_activation(
     email: citext!
-    secret_token: uuid!
   ): Status
 }
 


### PR DESCRIPTION
Voici le correctif :) avec ce nouveau format d'action, on peut également mettre en place un bouton pour renvoyer le mail de validation :)