### PR TITLE
fix(contributions): correction des liens vers les conventions collectives 

### DIFF
--- a/shared/elasticsearch-document-adapter/src/cdtnDocuments.ts
+++ b/shared/elasticsearch-document-adapter/src/cdtnDocuments.ts
@@ -174,6 +174,10 @@ export async function* cdtnDocumentsGen() {
 
   const ccnData = await getDocumentBySource<AgreementDoc>(SOURCES.CCN);
 
+  // we keep track of the idccs used in the contributions
+  // in order to flag the corresponding conventions collectives below
+  const contribIDCCs = updateContributionsAndGetIDCCs(contributions, ccnData);
+
   const ccnListWithHighlightFiltered = ccnData.filter((ccn) => {
     return ccn.highlight;
   });
@@ -236,9 +240,6 @@ export async function* cdtnDocumentsGen() {
   };
 
   logger.info("=== Conventions Collectives ===");
-  // we keep track of the idccs used in the contributions
-  // in order to flag the corresponding conventions collectives below
-  const contribIDCCs = updateContributionsAndGetIDCCs(contributions, ccnData);
 
   const ccnQR =
     "Retrouvez les questions-réponses les plus fréquentes organisées par thème et élaborées par le ministère du Travail concernant cette convention collective.";


### PR DESCRIPTION
fix #1125

J'ai relancé l'export sur mon PC et ça fonctionne bien 🤩
<img width="1157" alt="Screenshot 2023-11-20 at 13 14 13" src="https://github.com/SocialGouv/cdtn-admin/assets/25312957/8058ea29-b229-41d5-bd3c-410c89f1dbb0">
