### PR TITLE
fix(contributions): augmentation de la taille des titres des accordéons

### DIFF
--- a/targets/frontend/src/components/forms/EditionField/Editor.tsx
+++ b/targets/frontend/src/components/forms/EditionField/Editor.tsx
@@ -146,6 +146,11 @@ const StyledEditorContent = styled(EditorContent)(() => {
         ":first-of-type": {
           border: "none",
         },
+        summary: {
+          fontWeight: 600,
+          fontSize: "1.3rem",
+          fontFamily: '"Open Sans", sans-serif',
+        },
         "> button": {
           display: "flex",
           cursor: "pointer",


### PR DESCRIPTION
Voici le résultat : 

![CleanShot 2023-11-20 at 15 09 50@2x](https://github.com/SocialGouv/cdtn-admin/assets/992514/f6117631-cb36-4cc0-bafb-845b09141915)

et sans chatGPT pour le CSS 😄 