### PR TITLE
fix: update replicas for export

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -32,6 +32,7 @@ contributions:
       memory: "256Mi"
 
 export:
+  replicas: 1
   resources:
     limits:
       cpu: "1500m"


### PR DESCRIPTION
On désactive le HPA sur ce service qui n'en a pas besoin. Cela permet de retirer les alertes sur mattermost.