### PR TITLE
fix(contribution): autoriser un message block vide

### DIFF
--- a/shared/elasticsearch-document-adapter/src/contributions/__tests__/generateMessageBlock.test.ts
+++ b/shared/elasticsearch-document-adapter/src/contributions/__tests__/generateMessageBlock.test.ts
@@ -86,4 +86,16 @@ describe("generateMessageBlock", () => {
       "Unknown content type"
     );
   });
+
+  it("should return undefined if no message block setup for the question", async () => {
+    (fetchMessageBlock as jest.Mock).mockResolvedValue(undefined);
+
+    const result: string | undefined = await generateMessageBlock(
+      mockContribution
+    );
+
+    expect(result).toEqual(undefined);
+
+    expect(fetchMessageBlock).toHaveBeenCalledWith("123");
+  });
 });

--- a/shared/elasticsearch-document-adapter/src/contributions/fetchMessageBlock.ts
+++ b/shared/elasticsearch-document-adapter/src/contributions/fetchMessageBlock.ts
@@ -26,7 +26,7 @@ interface HasuraReturn {
 
 export async function fetchMessageBlock(
   questionId: string
-): Promise<ContributionMessageBlock> {
+): Promise<ContributionMessageBlock | undefined> {
   const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint");
   const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret");
   const res = await gqlClient({
@@ -40,10 +40,5 @@ export async function fetchMessageBlock(
   if (res.error) {
     throw res.error;
   }
-  if (!res.data?.contribution_questions_by_pk?.message) {
-    throw new Error(
-      `Impossible de récupérer la message block pour la question avec l'id ${questionId}`
-    );
-  }
-  return res.data.contribution_questions_by_pk.message;
+  return res.data?.contribution_questions_by_pk?.message;
 }

--- a/shared/elasticsearch-document-adapter/src/contributions/generateMessageBlock.ts
+++ b/shared/elasticsearch-document-adapter/src/contributions/generateMessageBlock.ts
@@ -6,8 +6,11 @@ import { fetchMessageBlock } from "./fetchMessageBlock";
 
 export const generateMessageBlock = async (
   contrib: DocumentElasticWithSource<ContributionDocumentJson>
-): Promise<string> => {
+): Promise<string | undefined> => {
   const messageBlock = await fetchMessageBlock(contrib.questionId);
+  if (!messageBlock) {
+    return undefined;
+  }
   if (
     contrib.idcc === "0000" || // Generic answer
     contrib.contentType === "UNKNOWN" ||

--- a/targets/frontend/src/components/contributions/questions/EditQuestion.tsx
+++ b/targets/frontend/src/components/contributions/questions/EditQuestion.tsx
@@ -6,7 +6,7 @@ import { QuestionAnswerList } from "./EditQuestionAnswerList";
 
 import { EditQuestionForm } from "./EditQuestionForm";
 import { useQuestionQuery } from "./Question.query";
-import { BreadcrumbLink } from "src/components/utils";
+import { Breadcrumb, BreadcrumbLink } from "src/components/utils";
 import { statusesMapping } from "../status/data";
 import { countAnswersWithStatus } from "../questionList";
 import { Answer } from "../type";
@@ -74,12 +74,12 @@ export const EditQuestion = ({
     });
     return (
       <>
-        <ol aria-label="breadcrumb" className="fr-breadcrumb__list">
+        <Breadcrumb>
           <BreadcrumbLink href={"/contributions"}>Contributions</BreadcrumbLink>
           <BreadcrumbLink>
             {`${data?.question?.order} - ${data?.question?.content}`}
           </BreadcrumbLink>
-        </ol>
+        </Breadcrumb>
         <Stack direction="row" alignItems="start" spacing={2}>
           <StatusStats
             total={answers.length}

--- a/targets/frontend/src/components/contributions/questions/Question.mutation.ts
+++ b/targets/frontend/src/components/contributions/questions/Question.mutation.ts
@@ -3,7 +3,7 @@ import { OperationResult, useMutation } from "urql";
 import { Question } from "../type";
 
 export const questionUpdateMutation = `
-mutation contributionQuestionUpdate($id: uuid!, $content: String, $message_id: uuid!) {
+mutation contributionQuestionUpdate($id: uuid!, $content: String, $message_id: uuid) {
   update_contribution_questions_by_pk(pk_columns: {id: $id}, _set: {content: $content, message_id: $message_id}) {
     __typename
   }

--- a/targets/frontend/src/components/contributions/type.ts
+++ b/targets/frontend/src/components/contributions/type.ts
@@ -131,11 +131,7 @@ export const questionBaseSchema = z.object({
     })
     .min(1, "Une question doit être renseignée"),
   order: z.number(),
-  message_id: z
-    .string({
-      required_error: "Un message doit être sélectionné",
-    })
-    .uuid("Un message doit être sélectionné"),
+  message_id: z.string().uuid().optional(),
 });
 
 export const commentsSchema = z.object({

--- a/targets/frontend/src/components/forms/EditionField/Editor.tsx
+++ b/targets/frontend/src/components/forms/EditionField/Editor.tsx
@@ -143,10 +143,9 @@ const StyledEditorContent = styled(EditorContent)(() => {
       ".alert": {
         marginBottom: "1.6rem",
         padding: "1.6rem 2rem",
-        color: "rgb(62, 72, 110)",
+        color: fr.colors.decisions.text.default,
         fontSize: "1.4rem",
-        backgroundColor: "rgb(242, 245, 250)",
-        border: "1px solid rgb(242, 245, 250)",
+        backgroundColor: fr.colors.decisions.background.contrast.info.active,
         borderRadius: "0.6rem",
       },
       ".details": {

--- a/targets/frontend/src/components/forms/EditionField/Editor.tsx
+++ b/targets/frontend/src/components/forms/EditionField/Editor.tsx
@@ -17,6 +17,7 @@ import { DetailsSummary } from "@tiptap-pro/extension-details-summary";
 import { DetailsContent } from "@tiptap-pro/extension-details-content";
 import { Placeholder } from "@tiptap/extension-placeholder";
 import { Link } from "@tiptap/extension-link";
+import { Alert } from "./extensions";
 
 export type EditorProps = {
   label: string;
@@ -71,6 +72,7 @@ export const Editor = ({
           rel: null,
         },
       }),
+      Alert,
     ],
     onUpdate: ({ editor }) => {
       const html = editor.getHTML();
@@ -137,6 +139,15 @@ const StyledEditorContent = styled(EditorContent)(() => {
       },
       "a::after": {
         display: "none",
+      },
+      ".alert": {
+        marginBottom: "1.6rem",
+        padding: "1.6rem 2rem",
+        color: "rgb(62, 72, 110)",
+        fontSize: "1.4rem",
+        backgroundColor: "rgb(242, 245, 250)",
+        border: "1px solid rgb(242, 245, 250)",
+        borderRadius: "0.6rem",
       },
       ".details": {
         display: "flex",

--- a/targets/frontend/src/components/forms/EditionField/MenuSpecial.tsx
+++ b/targets/frontend/src/components/forms/EditionField/MenuSpecial.tsx
@@ -4,6 +4,7 @@ import FormatListNumberedIcon from "@mui/icons-material/FormatListNumbered";
 import GridOnIcon from "@mui/icons-material/GridOn";
 import StorageIcon from "@mui/icons-material/Storage";
 import { styled } from "@mui/system";
+import InfoIcon from "@mui/icons-material/Info";
 
 const tableHTML = `
   <table style="width:100%">
@@ -66,6 +67,16 @@ export const MenuSpecial = ({ editor }: { editor: Editor | null }) => {
         title="Ajouter un accordéon"
       >
         <StorageIcon />
+      </button>
+      <button
+        onClick={() => {
+          editor?.chain().focus().setAlert().run();
+        }}
+        className={editor.isActive("alert") ? "is-active" : ""}
+        type="button"
+        title="Ajouter une section d'information"
+      >
+        <InfoIcon />
       </button>
     </StyledFloatingMenu>
   ) : (

--- a/targets/frontend/src/components/forms/EditionField/extensions/Alert.ts
+++ b/targets/frontend/src/components/forms/EditionField/extensions/Alert.ts
@@ -1,0 +1,68 @@
+import { mergeAttributes, Node, wrappingInputRule } from "@tiptap/core";
+
+export interface AlertOptions {}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    alert: {
+      setAlert: () => ReturnType;
+      toggleAlert: () => ReturnType;
+      unsetAlert: () => ReturnType;
+    };
+  }
+}
+
+export const inputRegex = /^\s*>\s$/;
+
+export const Alert = Node.create<AlertOptions>({
+  name: "alert",
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  content: "block+",
+
+  group: "block",
+
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "div" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes({ class: "alert" }, HTMLAttributes), 0];
+  },
+
+  addCommands() {
+    return {
+      setAlert:
+        () =>
+        ({ commands }) => {
+          return commands.wrapIn(this.name);
+        },
+      toggleBlockquote:
+        () =>
+        ({ commands }) => {
+          return commands.toggleWrap(this.name);
+        },
+      unsetBlockquote:
+        () =>
+        ({ commands }) => {
+          return commands.lift(this.name);
+        },
+    };
+  },
+
+  addInputRules() {
+    return [
+      wrappingInputRule({
+        find: inputRegex,
+        type: this.type,
+      }),
+    ];
+  },
+});

--- a/targets/frontend/src/components/forms/EditionField/extensions/index.ts
+++ b/targets/frontend/src/components/forms/EditionField/extensions/index.ts
@@ -1,0 +1,1 @@
+export * from "./Alert";


### PR DESCRIPTION
On peut maintenant mettre un message block vide à une question et on peut ajouter des blocks d'information (fond bleu) dans les contributions pour rédiger des message block dans le texte.

![CleanShot 2023-12-13 at 13 46 06](https://github.com/SocialGouv/cdtn-admin/assets/992514/ca170224-ab89-4695-9fb5-9ecfc1df5728)

Linked to https://github.com/SocialGouv/code-du-travail-numerique/issues/5475
