### PR TITLE
fix(contribution): changement de l'index de la question 54 à 55

### DIFF
--- a/targets/hasura/migrations/default/1702549668954_fix_question_55_index/down.sql
+++ b/targets/hasura/migrations/default/1702549668954_fix_question_55_index/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."files" add column "created_at" timestamptz
+--  not null default now();

--- a/targets/hasura/migrations/default/1702549668954_fix_question_55_index/up.sql
+++ b/targets/hasura/migrations/default/1702549668954_fix_question_55_index/up.sql
@@ -1,0 +1,6 @@
+UPDATE
+  contribution.questions
+SET
+  "order" = 55
+WHERE
+  id = 'd4e1154f-c486-40dc-8fc8-1a4fcd60ee6b';


### PR DESCRIPTION
Sous l'ancien outil de contribution , on a plusieurs index pour la même réponse et lors de la migration, on a choisi le mauvais index :(