### PR TITLE
fix(alert-cli): contenus éditoriaux qui peuvent être `undefined` si aucun n'élément est renseigné

### DIFF
--- a/shared/types/EditorialContent.ts
+++ b/shared/types/EditorialContent.ts
@@ -14,7 +14,7 @@ export declare enum BlockDisplayMode {
 export type BaseContentPart = {
   name: string;
   title: string;
-  references: EditoralContentReferenceBloc[];
+  references?: EditoralContentReferenceBloc[];
   blocks: EditorialContentPart[];
 };
 

--- a/targets/alert-cli/src/diff/dila/extractReferences/editorialContents.ts
+++ b/targets/alert-cli/src/diff/dila/extractReferences/editorialContents.ts
@@ -32,11 +32,13 @@ export async function extractEditorialContentTemplateRef(
   for (const docData of editorialContent) {
     const extractedArticleIds: string[] =
       docData.document.contents.flatMap<string>((part): string[] => {
-        return part.references.flatMap<string>(({ links }): string[] => {
-          return links.flatMap(({ url }): string[] => {
-            return extractArticleId(url);
-          });
-        });
+        return (part.references ?? []).flatMap<string>(
+          ({ links }): string[] => {
+            return links.flatMap(({ url }): string[] => {
+              return extractArticleId(url);
+            });
+          }
+        );
       });
     const articleIds: string[] = (docData.document.references ?? [])
       .flatMap((bloc: EditoralContentReferenceBloc) =>


### PR DESCRIPTION
fix #1210 