### PR TITLE
fix(ingester logs): add logs during ingester to debug contributions export

### DIFF
--- a/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
+++ b/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
@@ -207,7 +207,9 @@ export async function* cdtnDocumentsGen() {
     getBreadcrumbs
   );
 
-  logger.info(`Generated ${newGeneratedContributions.length} new contributions`);
+  logger.info(
+    `Generated ${newGeneratedContributions.length} new contributions`
+  );
 
   const oldGeneratedContributions = oldContributions.map(
     ({ answers, breadcrumbs, ...contribution }: any) => {
@@ -262,11 +264,19 @@ export async function* cdtnDocumentsGen() {
     }
   ) as unknown as OldContributionElasticDocument[];
 
-  logger.info(`Generated ${oldGeneratedContributions.length} old contributions`);
+  logger.info(
+    `Generated ${oldGeneratedContributions.length} old contributions`
+  );
 
-
+  const generatedContributions = [
+    ...newGeneratedContributions,
+    ...oldGeneratedContributions,
+  ];
+  if (generatedContributions.length < 1998) {
+    throw Error("Le nombre de contributions est inférieur à celui attendu");
+  }
   yield {
-    documents: [...newGeneratedContributions, ...oldGeneratedContributions],
+    documents: generatedContributions,
     source: SOURCES.CONTRIBUTIONS,
   };
 

--- a/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
+++ b/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
@@ -262,7 +262,7 @@ export async function* cdtnDocumentsGen() {
     }
   ) as unknown as OldContributionElasticDocument[];
 
-  logger.info(`Generated ${oldGeneratedContributions.length} new contributions`);
+  logger.info(`Generated ${oldGeneratedContributions.length} old contributions`);
 
 
   yield {

--- a/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
+++ b/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
@@ -28,8 +28,8 @@ import { keyFunctionParser } from "./utils";
 import { getVersions } from "./versions";
 import { DocumentElasticWithSource } from "./types/Glossary";
 import {
-  isNewContribution,
   generateContributions,
+  isNewContribution,
   isOldContribution,
 } from "./contributions";
 import { generateAgreements } from "./agreements";
@@ -164,8 +164,10 @@ export async function* cdtnDocumentsGen() {
     SOURCES.CONTRIBUTIONS,
     getBreadcrumbs
   );
+  logger.info(`Fetched ${contributions.length} contributions`);
 
   const ccnData = await getDocumentBySource<AgreementDoc>(SOURCES.CCN);
+  logger.info(`Fetched ${ccnData.length} conventions`);
 
   const ccnListWithHighlightFiltered = ccnData.filter((ccn) => {
     return ccn.highlight;
@@ -181,6 +183,7 @@ export async function* cdtnDocumentsGen() {
 
   const oldContributions: DocumentElasticWithSource<ContributionCompleteDoc>[] =
     contributions.filter(isOldContribution);
+  logger.info(`Fetched ${oldContributions.length} old contributions`);
 
   const breadcrumbsOfRootContributionsPerIndex = oldContributions.reduce(
     (state: Record<number, Breadcrumbs[]>, contribution: any) => {
@@ -193,6 +196,7 @@ export async function* cdtnDocumentsGen() {
   );
 
   const newContributions = contributions.filter(isNewContribution);
+  logger.info(`Fetched ${newContributions.length} new contributions`);
 
   const newGeneratedContributions = await generateContributions(
     newContributions,
@@ -202,6 +206,8 @@ export async function* cdtnDocumentsGen() {
     addGlossary,
     getBreadcrumbs
   );
+
+  logger.info(`Generated ${newGeneratedContributions.length} new contributions`);
 
   const oldGeneratedContributions = oldContributions.map(
     ({ answers, breadcrumbs, ...contribution }: any) => {
@@ -255,6 +261,9 @@ export async function* cdtnDocumentsGen() {
       return obj;
     }
   ) as unknown as OldContributionElasticDocument[];
+
+  logger.info(`Generated ${oldGeneratedContributions.length} new contributions`);
+
 
   yield {
     documents: [...newGeneratedContributions, ...oldGeneratedContributions],


### PR DESCRIPTION
Output
```
01-23 14:09:35.349 | info  | === Contributions === 
01-23 14:09:35.555 | info  | Fetched 1998 contributions 
01-23 14:09:35.587 | info  | Fetched 677 conventions 
01-23 14:09:35.589 | info  | Fetched 1510 old contributions 
01-23 14:09:35.589 | info  | Fetched 488 new contributions 
01-23 14:09:38.533 | info  | Generated 488 new contributions 
01-23 14:09:38.571 | info  | Generated 1510 old contributions 
01-23 14:09:38.572 | info  | › contributions... 1998 items 
01-23 14:09:38.572 | info  | done in 4.426 s
```