### PR TITLE
feat(export): migration de fetch vers urql

### DIFF
--- a/targets/export-elasticsearch/src/ingester/agreements/getAgreementsArticlesByTheme.ts
+++ b/targets/export-elasticsearch/src/ingester/agreements/getAgreementsArticlesByTheme.ts
@@ -86,8 +86,8 @@ export function generateArticleByTheme(
 export default async function getAgreementsArticlesByTheme(
   idccNumber: number
 ): Promise<ArticleByTheme[]> {
-  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint");
-  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret");
+  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint") || "http://localhost:8080/v1/graphql";
+  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret") ||"admin1";
   const resultKaliBlocks = await gqlClient({
     graphqlEndpoint: HASURA_GRAPHQL_ENDPOINT,
     adminSecret: HASURA_GRAPHQL_ENDPOINT_SECRET,

--- a/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
+++ b/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
@@ -10,20 +10,16 @@ import {
 } from "@shared/types";
 import { logger } from "@shared/utils";
 import { SOURCES } from "@socialgouv/cdtn-sources";
-import fetch from "node-fetch";
 
 import { buildGetBreadcrumbs } from "./breadcrumbs";
 import { buildThemes } from "./buildThemes";
-import { context } from "./context";
 import {
   getDocumentBySource,
   getDocumentBySourceWithRelation,
-  getGlossary,
-} from "./fetchCdtnAdminDocuments";
+} from "./documents/fetchCdtnAdminDocuments";
 import { splitArticle } from "./fichesTravailSplitter";
 import { createGlossaryTransform } from "./glossary";
 import { markdownTransform } from "./markdown";
-import type { ThemeQueryResult } from "./types/themes";
 import { keyFunctionParser } from "./utils";
 import { getVersions } from "./versions";
 import { DocumentElasticWithSource } from "./types/Glossary";
@@ -33,33 +29,8 @@ import {
   isOldContribution,
 } from "./contributions";
 import { generateAgreements } from "./agreements";
-
-const themesQuery = JSON.stringify({
-  query: `{
-  themes: documents(where: {source: {_eq: "${SOURCES.THEMES}"}}) {
-    cdtnId: cdtn_id
-    id: initial_id
-    slug
-    source
-    title
-    document
-    contentRelations: relation_a(where: {type: {_eq: "theme-content"}, b: {is_published: {_eq: true}, is_available: {_eq: true}}}, order_by: {}) {
-      content: b {
-        cdtnId: cdtn_id
-        slug
-        source
-        title
-        document
-      }
-      position: data(path: "position")
-    }
-    parentRelations: relation_b(where: {type: {_eq: "theme"}}) {
-      parentThemeId: document_a
-      position: data(path: "position")
-    }
-  }
-}`,
-});
+import { getGlossary } from "./documents/fetchGlossary";
+import { fetchThemes } from "./themes/fetchThemes";
 
 /**
  * Find duplicate slugs
@@ -85,30 +56,10 @@ export async function getDuplicateSlugs(allDocuments: any) {
     );
 }
 
-export async function* cdtnDocumentsGen() {
-  const CDTN_ADMIN_ENDPOINT =
-    context.get("cdtnAdminEndpoint") || "http://localhost:8080/v1/graphql";
-
-  console.error(`Accessing cdtn admin on ${CDTN_ADMIN_ENDPOINT}`);
-  const themesQueryResult = await fetch(CDTN_ADMIN_ENDPOINT, {
-    body: themesQuery,
-    method: "POST",
-  }).then(async (r: any) => {
-    const data = await r.json();
-    if (r.ok) {
-      return data as ThemeQueryResult;
-    }
-    return Promise.reject(data);
-  });
-
-  if (!themesQueryResult.data) {
-    throw new Error(
-      `Requête pour récupérer les thèmes a échoué ${JSON.stringify(
-        themesQueryResult.errors
-      )}`
-    );
-  }
-  const themes = themesQueryResult.data.themes;
+export async function cdtnDocumentsGen(
+  updateDocs: (source: string, documents: unknown[]) => Promise<void>
+) {
+  const themes = await fetchThemes();
 
   const getBreadcrumbs = buildGetBreadcrumbs(themes);
 
@@ -125,37 +76,34 @@ export async function* cdtnDocumentsGen() {
     SOURCES.EDITORIAL_CONTENT,
     getBreadcrumbs
   );
-  yield {
-    documents: markdownTransform(addGlossary, documents),
-    source: SOURCES.EDITORIAL_CONTENT,
-  };
+  await updateDocs(
+    SOURCES.EDITORIAL_CONTENT,
+    markdownTransform(addGlossary, documents)
+  );
 
   logger.info("=== Courriers ===");
-  yield {
-    documents: await getDocumentBySource(SOURCES.LETTERS, getBreadcrumbs),
-    source: SOURCES.LETTERS,
-  };
+  await updateDocs(
+    SOURCES.LETTERS,
+    await getDocumentBySource(SOURCES.LETTERS, getBreadcrumbs)
+  );
 
   logger.info("=== Outils ===");
-  yield {
-    documents: await getDocumentBySource(SOURCES.TOOLS, getBreadcrumbs),
-    source: SOURCES.TOOLS,
-  };
+  await updateDocs(
+    SOURCES.TOOLS,
+    await getDocumentBySource(SOURCES.TOOLS, getBreadcrumbs)
+  );
 
   logger.info("=== Outils externes ===");
-  yield {
-    documents: await getDocumentBySource(SOURCES.EXTERNALS, getBreadcrumbs),
-    source: SOURCES.EXTERNALS,
-  };
+  await updateDocs(
+    SOURCES.EXTERNALS,
+    await getDocumentBySource(SOURCES.EXTERNALS, getBreadcrumbs)
+  );
 
   logger.info("=== Dossiers ===");
-  yield {
-    documents: await getDocumentBySource(
-      SOURCES.THEMATIC_FILES,
-      getBreadcrumbs
-    ),
-    source: SOURCES.THEMATIC_FILES,
-  };
+  await updateDocs(
+    SOURCES.THEMATIC_FILES,
+    await getDocumentBySource(SOURCES.THEMATIC_FILES, getBreadcrumbs)
+  );
 
   logger.info("=== Contributions ===");
   const contributions: DocumentElasticWithSource<
@@ -279,10 +227,7 @@ export async function* cdtnDocumentsGen() {
     );
   }
 
-  yield {
-    documents: generatedContributions,
-    source: SOURCES.CONTRIBUTIONS,
-  };
+  await updateDocs(SOURCES.CONTRIBUTIONS, generatedContributions);
 
   logger.info("=== Conventions Collectives ===");
   const agreementsDocs = await generateAgreements(
@@ -291,24 +236,22 @@ export async function* cdtnDocumentsGen() {
     oldGeneratedContributions
   );
 
-  yield {
-    documents: agreementsDocs,
-    source: SOURCES.CCN,
-  };
+  await updateDocs(SOURCES.CCN, agreementsDocs);
 
   logger.info("=== Fiches SP ===");
-  yield {
-    documents: await getDocumentBySource(SOURCES.SHEET_SP, getBreadcrumbs),
-    source: SOURCES.SHEET_SP,
-  };
+  await updateDocs(
+    SOURCES.SHEET_SP,
+    await getDocumentBySource(SOURCES.SHEET_SP, getBreadcrumbs)
+  );
 
   logger.info("=== page fiches travail ===");
   const fichesMT = await getDocumentBySource<FicheTravailEmploiDoc>(
     SOURCES.SHEET_MT_PAGE,
     getBreadcrumbs
   );
-  yield {
-    documents: fichesMT.map(({ sections, ...infos }) => ({
+  await updateDocs(
+    SOURCES.SHEET_MT_PAGE,
+    fichesMT.map(({ sections, ...infos }) => ({
       ...infos,
       sections: sections.map(({ html, ...section }: any) => {
         delete section.description;
@@ -318,14 +261,14 @@ export async function* cdtnDocumentsGen() {
           html: addGlossary(html),
         };
       }),
-    })),
-    source: SOURCES.SHEET_MT_PAGE,
-  };
+    }))
+  );
 
   logger.info("=== Fiche MT ===");
   const splittedFiches = fichesMT.flatMap(splitArticle);
-  yield {
-    documents: splittedFiches.map((fiche) => {
+  await updateDocs(
+    SOURCES.SHEET_MT,
+    splittedFiches.map((fiche) => {
       // we don't want splitted fiches to have the same cdtnId than full pages
       // it causes bugs, tons of weird bugs, but we need the id for the
       // breadcrumbs generation
@@ -336,15 +279,11 @@ export async function* cdtnDocumentsGen() {
         breadcrumbs,
         source: SOURCES.SHEET_MT,
       };
-    }),
-    source: SOURCES.SHEET_MT,
-  };
+    })
+  );
 
   logger.info("=== Themes ===");
-  yield {
-    documents: buildThemes(themes, getBreadcrumbs),
-    source: SOURCES.THEMES,
-  };
+  await updateDocs(SOURCES.THEMES, buildThemes(themes, getBreadcrumbs));
 
   logger.info("=== Highlights ===");
   const highlights = await getDocumentBySourceWithRelation(
@@ -368,10 +307,7 @@ export async function* cdtnDocumentsGen() {
       return ref;
     }),
   }));
-  yield {
-    documents: highlightsWithContrib,
-    source: SOURCES.HIGHLIGHTS,
-  };
+  await updateDocs(SOURCES.HIGHLIGHTS, highlightsWithContrib);
 
   logger.info("=== PreQualified Request ===");
   const prequalified = await getDocumentBySourceWithRelation(
@@ -395,36 +331,24 @@ export async function* cdtnDocumentsGen() {
       return ref;
     }),
   }));
-  yield {
-    documents: prequalifiedWithContrib,
-    source: SOURCES.PREQUALIFIED,
-  };
+  await updateDocs(SOURCES.PREQUALIFIED, prequalifiedWithContrib);
 
   logger.info("=== glossary ===");
-  yield {
-    documents: [
-      {
-        data: glossaryTerms,
-        source: SOURCES.GLOSSARY,
-      },
-    ],
-    source: SOURCES.GLOSSARY,
-  };
+  await updateDocs(SOURCES.GLOSSARY, [
+    {
+      data: glossaryTerms,
+      source: SOURCES.GLOSSARY,
+    },
+  ]);
 
   logger.info("=== Code du travail ===");
-  yield {
-    documents: await getDocumentBySource(SOURCES.CDT),
-    source: SOURCES.CDT,
-  };
+  await updateDocs(SOURCES.CDT, await getDocumentBySource(SOURCES.CDT));
 
   logger.info("=== data version ===");
-  yield {
-    documents: [
-      {
-        data: getVersions(),
-        source: SOURCES.VERSIONS,
-      },
-    ],
-    source: SOURCES.VERSIONS,
-  };
+  await updateDocs(SOURCES.VERSIONS, [
+    {
+      data: getVersions(),
+      source: SOURCES.VERSIONS,
+    },
+  ]);
 }

--- a/targets/export-elasticsearch/src/ingester/contributions/fetchFicheSp.ts
+++ b/targets/export-elasticsearch/src/ingester/contributions/fetchFicheSp.ts
@@ -24,8 +24,8 @@ interface HasuraReturn {
 export async function fetchFicheSp(
   ficheSpId: string
 ): Promise<FicheServicePublicDoc> {
-  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint");
-  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret");
+  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint") || "http://localhost:8080/v1/graphql";
+  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret") ||"admin1";
   const res = await gqlClient({
     graphqlEndpoint: HASURA_GRAPHQL_ENDPOINT,
     adminSecret: HASURA_GRAPHQL_ENDPOINT_SECRET,

--- a/targets/export-elasticsearch/src/ingester/contributions/fetchLinkedContent.ts
+++ b/targets/export-elasticsearch/src/ingester/contributions/fetchLinkedContent.ts
@@ -31,8 +31,8 @@ export async function fetchLinkedContent(
   questionIndex: number,
   idcc: string
 ): Promise<LinkedContentLight | undefined> {
-  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint");
-  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret");
+  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint") || "http://localhost:8080/v1/graphql";
+  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret") ||"admin1";
   const res = await gqlClient({
     graphqlEndpoint: HASURA_GRAPHQL_ENDPOINT,
     adminSecret: HASURA_GRAPHQL_ENDPOINT_SECRET,

--- a/targets/export-elasticsearch/src/ingester/contributions/fetchMessageBlock.ts
+++ b/targets/export-elasticsearch/src/ingester/contributions/fetchMessageBlock.ts
@@ -27,8 +27,8 @@ interface HasuraReturn {
 export async function fetchMessageBlock(
   questionId: string
 ): Promise<ContributionMessageBlock | undefined> {
-  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint");
-  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret");
+  const HASURA_GRAPHQL_ENDPOINT = context.get("cdtnAdminEndpoint") || "http://localhost:8080/v1/graphql";
+  const HASURA_GRAPHQL_ENDPOINT_SECRET = context.get("cdtnAdminEndpointSecret") || "admin1";
   const res = await gqlClient({
     graphqlEndpoint: HASURA_GRAPHQL_ENDPOINT,
     adminSecret: HASURA_GRAPHQL_ENDPOINT_SECRET,

--- a/targets/export-elasticsearch/src/ingester/documents/fetchGlossary.ts
+++ b/targets/export-elasticsearch/src/ingester/documents/fetchGlossary.ts
@@ -1,0 +1,35 @@
+import type { Glossary } from "../types";
+import { context } from "../context";
+import { gqlClient } from "@shared/utils";
+
+const gqlGlossary = `
+query Glossary {
+  glossary {
+    term
+    abbreviations
+    definition
+    variants
+  }
+}
+
+`;
+
+export async function getGlossary(): Promise<Glossary> {
+  const graphqlEndpoint: string =
+    context.get("cdtnAdminEndpoint") || "http://localhost:8080/v1/graphql";
+  const adminSecret: string =
+    context.get("cdtnAdminEndpointSecret") || "admin1";
+  const result = await gqlClient({
+    graphqlEndpoint,
+    adminSecret,
+  })
+    .query<{ glossary: Glossary }>(gqlGlossary)
+    .toPromise();
+  if (result.error || !result.data) {
+    console.error(result.error);
+    throw new Error(
+      `error fetching kali blocks => ${JSON.stringify(result.error)}`
+    );
+  }
+  return result.data.glossary;
+}

--- a/targets/export-elasticsearch/src/ingester/ingest.ts
+++ b/targets/export-elasticsearch/src/ingester/ingest.ts
@@ -212,32 +212,3 @@ async function runIngester(
 
   await deleteOldIndex({ client, patterns, timestamp: ts });
 }
-
-const generateUpdateDocument = (
-  client: Client,
-  indexName: string,
-  ts: number
-) => {
-  return async function updateDoc(source: string, documents: any[]) {
-    logger.info(`› ${source}... ${documents.length} items`);
-
-    let docs = documents;
-
-    docs.forEach((doc: any) => {
-      addCovisits(doc);
-    });
-
-    // add NLP vectors
-    if (!(excludeSources as string[]).includes(source)) {
-      docs = await pMap(documents, addVector, {
-        concurrency: 5,
-      });
-    }
-    await indexDocumentsBatched({
-      client,
-      documents: docs,
-      indexName: `${indexName}-${ts}`,
-      size: 800,
-    });
-  };
-};

--- a/targets/export-elasticsearch/src/ingester/themes/fetchThemes.ts
+++ b/targets/export-elasticsearch/src/ingester/themes/fetchThemes.ts
@@ -1,0 +1,55 @@
+import { context } from "../context";
+import { gqlClient } from "@shared/utils";
+import { Data, Theme } from "../types/themes";
+import { SOURCES } from "@socialgouv/cdtn-sources";
+
+const graphQLThemesQuery = `
+{
+  themes: documents(where: {source: {_eq: "${SOURCES.THEMES}"}}) {
+    cdtnId: cdtn_id
+    id: initial_id
+    slug
+    source
+    title
+    document
+    contentRelations: relation_a(where: {type: {_eq: "theme-content"}, b: {is_published: {_eq: true}, is_available: {_eq: true}}}, order_by: {}) {
+      content: b {
+        cdtnId: cdtn_id
+        slug
+        source
+        title
+        document
+      }
+      position: data(path: "position")
+    }
+    parentRelations: relation_b(where: {type: {_eq: "theme"}}) {
+      parentThemeId: document_a
+      position: data(path: "position")
+    }
+  }
+}`;
+
+export const fetchThemes = async (): Promise<Theme[]> => {
+  const graphqlEndpoint =
+    context.get("cdtnAdminEndpoint") || "http://localhost:8080/v1/graphql";
+  const adminSecret: string =
+    context.get("cdtnAdminEndpointSecret") || "admin1";
+
+  console.error(`Accessing cdtn admin on ${graphqlEndpoint}`);
+  const result = await gqlClient({
+    graphqlEndpoint,
+    adminSecret,
+  })
+    .query<Data>(graphQLThemesQuery)
+    .toPromise();
+
+  if (result.error || !result.data) {
+    throw new Error(
+      `Requête pour récupérer les thèmes a échoué ${JSON.stringify(
+        result.error
+      )}`
+    );
+  }
+
+  return result.data.themes;
+};

--- a/targets/export-elasticsearch/src/ingester/types/themes.ts
+++ b/targets/export-elasticsearch/src/ingester/types/themes.ts
@@ -1,12 +1,8 @@
-import type { GraphQLResponseRoot } from "./GraphQL";
-
-export type ThemeQueryResult = GraphQLResponseRoot<Data>;
-
-export type Data = {
+export interface Data {
   themes: Theme[];
-};
+}
 
-export type Theme = {
+export interface Theme {
   cdtnId: string;
   id: string;
   slug: string;
@@ -15,28 +11,28 @@ export type Theme = {
   document: ThemeDocument;
   contentRelations: ThemeContentRelation[];
   parentRelations: ThemeParentRelation[];
-};
+}
 
-export type ThemeDocument = {
+export interface ThemeDocument {
   icon?: string;
   shortTitle?: string;
   description?: string;
-};
+}
 
-export type ThemeContentRelation = {
+export interface ThemeContentRelation {
   content: ThemeContent;
   position: number;
-};
+}
 
-export type ThemeContent = {
+export interface ThemeContent {
   cdtnId: string;
   slug: string;
   source: string;
   title: string;
   document: unknown;
-};
+}
 
-export type ThemeParentRelation = {
+export interface ThemeParentRelation {
   parentThemeId?: string;
   position: number;
-};
+}

--- a/targets/export-elasticsearch/src/services/export.ts
+++ b/targets/export-elasticsearch/src/services/export.ts
@@ -30,51 +30,57 @@ export class ExportService {
     environment: Environment
   ): Promise<ExportEsStatus> {
     logger.info(`[${userId}] run export for ${environment}`);
-    let isReadyToRun = false;
-    const runningResult = await this.getRunningExport();
-    if (runningResult.length > 0) {
-      isReadyToRun = await this.cleanPreviousExport(
-        runningResult[0],
-        process.env.DISABLE_LIMIT_EXPORT ? 0 : 1
-      ); // we can avoid to do that with a queue system (e.g. RabbitMQ, Kafka, etc.)
-    }
-    if (runningResult.length === 0 || isReadyToRun) {
-      const id = randomUUID();
-      await this.exportRepository.create(
-        id,
-        userId,
-        environment,
-        Status.running
-      );
-      try {
-        if (!process.env.DISABLE_INGESTER) {
-          if (environment === Environment.preproduction) {
-            await runWorkerIngesterPreproduction();
-          } else {
-            await runWorkerIngesterProduction();
-          }
-        }
-        if (!process.env.DISABLE_SITEMAP) {
-          await this.sitemapService.uploadSitemap();
-        }
-        if (!process.env.DISABLE_COPY) {
-          await this.copyContainerService.runCopy();
-        }
-        return await this.exportRepository.updateOne(
-          id,
-          Status.completed,
-          new Date()
-        );
-      } catch (e: any) {
-        return await this.exportRepository.updateOne(
-          id,
-          Status.failed,
-          new Date(),
-          e.message
-        );
+    try {
+      let isReadyToRun = false;
+      const runningResult = await this.getRunningExport();
+      if (runningResult.length > 0) {
+        isReadyToRun = await this.cleanPreviousExport(
+          runningResult[0],
+          process.env.DISABLE_LIMIT_EXPORT ? 0 : 1
+        ); // we can avoid to do that with a queue system (e.g. RabbitMQ, Kafka, etc.)
       }
-    } else {
-      throw new Error("There is already a running job");
+      if (runningResult.length === 0 || isReadyToRun) {
+        const id = randomUUID();
+        await this.exportRepository.create(
+          id,
+          userId,
+          environment,
+          Status.running
+        );
+        try {
+          if (!process.env.DISABLE_INGESTER) {
+            if (environment === Environment.preproduction) {
+              await runWorkerIngesterPreproduction();
+            } else {
+              await runWorkerIngesterProduction();
+            }
+          }
+          if (!process.env.DISABLE_SITEMAP) {
+            await this.sitemapService.uploadSitemap();
+          }
+          if (!process.env.DISABLE_COPY) {
+            await this.copyContainerService.runCopy();
+          }
+          return await this.exportRepository.updateOne(
+            id,
+            Status.completed,
+            new Date()
+          );
+        } catch (e: any) {
+          logger.error(`Error: ${JSON.stringify(e)}`);
+          return await this.exportRepository.updateOne(
+            id,
+            Status.failed,
+            new Date(),
+            e.message
+          );
+        }
+      } else {
+        throw new Error("There is already a running job");
+      }
+    } catch (e: any) {
+      logger.error(`Error: ${JSON.stringify(e)}`);
+      throw e;
     }
   }
 


### PR DESCRIPTION
Migration de fetch vers urql pour les appels sur la base de données.

Depuis la mise à jour d'hasura, les calls en fetch échouent si on demande trop de données. Comme on utilise urql sur les nouveaux devs de l'export, autant basculer les quelques requêtes en fetch restantes.

Note: J'ai également retiré la fonction génératrice. A voir si ça améliore le debug...