### PR TITLE
fix(types): utilisation de `cdtn-utils` au lieu de `cdtn-source` qui n'est plus d'actualité

### DIFF
--- a/shared/types/package.json
+++ b/shared/types/package.json
@@ -23,6 +23,7 @@
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
+    "@socialgouv/cdtn-utils": "^4.156.1",
     "@socialgouv/kali-data-types": "^2.127.0",
     "@socialgouv/legi-data-types": "^2.73.1",
     "typescript": "^5.4.3"

--- a/shared/types/src/elastic/agreements.ts
+++ b/shared/types/src/elastic/agreements.ts
@@ -1,9 +1,10 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
 import { AgreementDoc } from "../hasura";
 import { DocumentElasticWithSource } from "./common";
 
 export type ElasticAgreement = DocumentElasticWithSource<AgreementDoc> & {
   articlesByTheme: ArticleByTheme[];
-  source: "conventions_collectives";
+  source: typeof SOURCES.CCN;
   description: string;
   answers: AnswerByTheme[];
   contributions: boolean;

--- a/shared/types/src/elastic/code-du-travail.ts
+++ b/shared/types/src/elastic/code-du-travail.ts
@@ -1,6 +1,8 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
 import { LaborCodeDoc } from "../hasura";
 import { DocumentElasticWithSource } from "./common";
 
 export type ElasticLaborCodeArticle = DocumentElasticWithSource<
-  Omit<LaborCodeDoc, "cid">
+  Omit<LaborCodeDoc, "cid">,
+  typeof SOURCES.CDT
 >;

--- a/shared/types/src/elastic/common.ts
+++ b/shared/types/src/elastic/common.ts
@@ -1,9 +1,9 @@
-import { SourceRoute } from "@socialgouv/cdtn-sources";
+import { SourceKeys } from "@socialgouv/cdtn-utils";
 import { ContributionsAnswers } from "../hasura";
 
 export type DocumentElasticWithSource<
   T,
-  U extends SourceRoute = SourceRoute
+  U extends SourceKeys = SourceKeys
 > = DocumentElastic<U> & T;
 
 export type Breadcrumb = {
@@ -12,7 +12,7 @@ export type Breadcrumb = {
   slug: string;
 };
 
-export type DocumentElastic<T extends SourceRoute = SourceRoute> = {
+export type DocumentElastic<T extends SourceKeys = SourceKeys> = {
   id: string;
   cdtnId: string;
   breadcrumbs: Breadcrumb[];
@@ -27,7 +27,7 @@ export type DocumentElastic<T extends SourceRoute = SourceRoute> = {
   contribution?: ContributionsAnswers;
 };
 
-export type RelatedDocument<T extends SourceRoute = SourceRoute> = {
+export type RelatedDocument<T extends SourceKeys = SourceKeys> = {
   id: string;
   cdtnId: string;
   breadcrumbs: Breadcrumb[];
@@ -40,7 +40,7 @@ export type RelatedDocument<T extends SourceRoute = SourceRoute> = {
   url?: string; // Pour les outils externes
 };
 
-export type DocumentRef<T extends SourceRoute = SourceRoute> = Omit<
+export type DocumentRef<T extends SourceKeys = SourceKeys> = Omit<
   RelatedDocument<T>,
   "action" | "url" | "id"
 >;

--- a/shared/types/src/elastic/contributions.ts
+++ b/shared/types/src/elastic/contributions.ts
@@ -1,5 +1,6 @@
 import { ContributionDocumentJson, ContributionHighlight } from "../hasura";
 import { Breadcrumb, DocumentElasticWithSource } from "./common";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export interface ContributionConventionnelInfos {
   ccnSlug: string;
@@ -101,7 +102,7 @@ type ElasticSearchContributionBase = {
   description: string;
   slug: string;
   breadcrumbs: Breadcrumb[];
-  source: "contributions";
+  source: typeof SOURCES.CONTRIBUTIONS;
   linkedContent: ContributionLinkedContent[];
   references: ContributionRef[];
   idcc: string;

--- a/shared/types/src/elastic/editorial-content.ts
+++ b/shared/types/src/elastic/editorial-content.ts
@@ -1,11 +1,12 @@
 import { EditorialContentDoc } from "../hasura";
 import { KeysToCamelCase } from "../utility";
 import { DocumentElasticWithSource } from "./common";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export type EditorialContentElasticDocument = Omit<
   DocumentElasticWithSource<
     KeysToCamelCase<EditorialContentDoc>,
-    "information"
+    typeof SOURCES.EDITORIAL_CONTENT
   >,
   "introWithGlossary"
 >;

--- a/shared/types/src/elastic/fiche-travail.ts
+++ b/shared/types/src/elastic/fiche-travail.ts
@@ -4,7 +4,7 @@ import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export type ElasticFicheTravailEmploi = DocumentElasticWithSource<
   Omit<FicheTravailEmploiDoc, "sections">,
-  typeof SOURCES.SHEET_MT | typeof SOURCES.SHEET_MT_PAGE
+  typeof SOURCES.SHEET_MT_PAGE
 > & {
   sections: ElasticFicheTravailEmploiSection[];
 };

--- a/shared/types/src/elastic/fiche-travail.ts
+++ b/shared/types/src/elastic/fiche-travail.ts
@@ -1,8 +1,10 @@
 import { DocumentElasticWithSource } from "./common";
 import { FicheTravailEmploiDoc, Section } from "../hasura";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export type ElasticFicheTravailEmploi = DocumentElasticWithSource<
-  Omit<FicheTravailEmploiDoc, "sections">
+  Omit<FicheTravailEmploiDoc, "sections">,
+  typeof SOURCES.SHEET_MT | typeof SOURCES.SHEET_MT_PAGE
 > & {
   sections: ElasticFicheTravailEmploiSection[];
 };

--- a/shared/types/src/elastic/highlights.ts
+++ b/shared/types/src/elastic/highlights.ts
@@ -1,7 +1,8 @@
 import { Highlight } from "../hasura";
 import { DocumentElasticWithSource } from "./common";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export type HighlightDocument = DocumentElasticWithSource<
   Highlight,
-  "highlights"
+  typeof SOURCES.HIGHLIGHTS
 >;

--- a/shared/types/src/elastic/modeles-de-courrier.ts
+++ b/shared/types/src/elastic/modeles-de-courrier.ts
@@ -1,7 +1,8 @@
 import { DocumentElasticWithSource } from "./common";
 import { MailTemplateDoc } from "../hasura";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export type MailElasticDocument = DocumentElasticWithSource<
   MailTemplateDoc,
-  "modeles_de_courriers"
+  typeof SOURCES.LETTERS
 >;

--- a/shared/types/src/elastic/prequalified.ts
+++ b/shared/types/src/elastic/prequalified.ts
@@ -1,8 +1,9 @@
 import { PrequalifiedDoc } from "../hasura";
 import { DocumentElasticWithSource, RelatedDocument } from "./common";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export type PrequalifiedElasticDocument = Omit<
-  DocumentElasticWithSource<PrequalifiedDoc, "prequalified">,
+  DocumentElasticWithSource<PrequalifiedDoc, typeof SOURCES.PREQUALIFIED>,
   "slug" | "refs"
 > & {
   refs: RelatedDocument[];

--- a/shared/types/src/elastic/theme.ts
+++ b/shared/types/src/elastic/theme.ts
@@ -1,8 +1,9 @@
 import { DocumentElasticWithSource } from "./common";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
 export type ThemeElasticDocument = DocumentElasticWithSource<
   ThemeElastic,
-  "themes"
+  typeof SOURCES.THEMES
 >;
 
 export type ThemeElastic = {

--- a/shared/types/src/elastic/tools.ts
+++ b/shared/types/src/elastic/tools.ts
@@ -1,3 +1,5 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
+
 export type Tool = {
   date: string;
   icon: string;
@@ -14,7 +16,7 @@ export type Tool = {
   isPublished: boolean;
   metaDescription: string;
   slug: string;
-  source: "outils";
+  source: typeof SOURCES.TOOLS;
   text: string;
   title: string;
   _id: string;

--- a/shared/types/src/hasura/agreement.ts
+++ b/shared/types/src/hasura/agreement.ts
@@ -1,8 +1,9 @@
 import { IndexedAgreement } from "@socialgouv/kali-data-types";
 import { HasuraDocument } from "./common";
 import { ContributionHighlight } from "./contributions";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
-export type Agreement = HasuraDocument<AgreementDoc, "conventions_collectives">;
+export type Agreement = HasuraDocument<AgreementDoc, typeof SOURCES.CCN>;
 
 export type AgreementDoc = Pick<
   IndexedAgreement,

--- a/shared/types/src/hasura/code-du-travail.ts
+++ b/shared/types/src/hasura/code-du-travail.ts
@@ -1,7 +1,8 @@
 import { CodeArticleData } from "@socialgouv/legi-data-types";
 import { HasuraDocument } from "./common";
+import { SOURCES } from "@socialgouv/cdtn-utils";
 
-export type LaborCodeArticle = HasuraDocument<LaborCodeDoc, "code_du_travail">;
+export type LaborCodeArticle = HasuraDocument<LaborCodeDoc, typeof SOURCES.CDT>;
 
 export type LaborCodeDoc = Pick<CodeArticleData, "cid" | "dateDebut" | "id"> & {
   description: string;

--- a/shared/types/src/hasura/common.ts
+++ b/shared/types/src/hasura/common.ts
@@ -1,6 +1,6 @@
-import { SourceRoute } from "@socialgouv/cdtn-sources";
+import { SourceKeys } from "@socialgouv/cdtn-utils";
 
-export type HasuraDocument<T, U extends SourceRoute = SourceRoute> = {
+export type HasuraDocument<T, U extends SourceKeys = SourceKeys> = {
   cdtn_id: string;
   initial_id: string;
   source: U;

--- a/shared/types/src/hasura/editorial-content.ts
+++ b/shared/types/src/hasura/editorial-content.ts
@@ -1,3 +1,4 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
 import { HasuraDocument } from "./common";
 
 export enum EditorialContentType {
@@ -87,5 +88,5 @@ export type EditorialContentDoc = {
 
 export type EditorialContent = HasuraDocument<
   EditorialContentDoc,
-  "information"
+  typeof SOURCES.EDITORIAL_CONTENT
 >;

--- a/shared/types/src/hasura/fiche-sp.ts
+++ b/shared/types/src/hasura/fiche-sp.ts
@@ -1,8 +1,9 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
 import { HasuraDocument } from "./common";
 
 export type FicheServicePublic = HasuraDocument<
   FicheServicePublicDoc,
-  "fiches_service_public"
+  typeof SOURCES.SHEET_SP
 >;
 
 export interface FicheServicePublicDoc {

--- a/shared/types/src/hasura/fiche-travail.ts
+++ b/shared/types/src/hasura/fiche-travail.ts
@@ -1,8 +1,9 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
 import { HasuraDocument } from "./common";
 
 export type FicheTravailEmploi = HasuraDocument<
   FicheTravailEmploiDoc,
-  "fiches_ministere_travail"
+  typeof SOURCES.SHEET_MT | typeof SOURCES.SHEET_MT_PAGE
 >;
 
 export interface FicheTravailEmploiDoc {

--- a/shared/types/src/hasura/fiche-travail.ts
+++ b/shared/types/src/hasura/fiche-travail.ts
@@ -3,7 +3,7 @@ import { HasuraDocument } from "./common";
 
 export type FicheTravailEmploi = HasuraDocument<
   FicheTravailEmploiDoc,
-  typeof SOURCES.SHEET_MT | typeof SOURCES.SHEET_MT_PAGE
+  typeof SOURCES.SHEET_MT_PAGE
 >;
 
 export interface FicheTravailEmploiDoc {

--- a/shared/types/src/hasura/fiche-travail.ts
+++ b/shared/types/src/hasura/fiche-travail.ts
@@ -3,7 +3,7 @@ import { HasuraDocument } from "./common";
 
 export type FicheTravailEmploi = HasuraDocument<
   FicheTravailEmploiDoc,
-  typeof SOURCES.SHEET_MT_PAGE
+  typeof SOURCES.SHEET_MT_PAGE | typeof SOURCES.SHEET_MT
 >;
 
 export interface FicheTravailEmploiDoc {

--- a/shared/types/src/hasura/highlights.ts
+++ b/shared/types/src/hasura/highlights.ts
@@ -1,3 +1,4 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
 import { HasuraDocument } from "./common";
 
-export type Highlight = HasuraDocument<any, "highlights">;
+export type Highlight = HasuraDocument<any, typeof SOURCES.HIGHLIGHTS>;

--- a/shared/types/src/hasura/modeles-de-courrier.ts
+++ b/shared/types/src/hasura/modeles-de-courrier.ts
@@ -1,8 +1,9 @@
+import { SOURCES } from "@socialgouv/cdtn-utils";
 import { HasuraDocument } from "./common";
 
 export type MailTemplate = HasuraDocument<
   MailTemplateDoc,
-  "modeles_de_courriers"
+  typeof SOURCES.LETTERS
 >;
 
 export type MailTemplateDoc = {

--- a/targets/alert-cli/src/diff/dila/extractReferences/__tests__/ficheTravailEmploi.test.ts
+++ b/targets/alert-cli/src/diff/dila/extractReferences/__tests__/ficheTravailEmploi.test.ts
@@ -74,7 +74,7 @@ const mockFiches: FicheTravail[] = [
       url: "https://travail-emploi",
     },
     initialId: "fiche-sp-1",
-    source: "fiches_ministere_travail",
+    source: "page_fiche_ministere_travail",
     title: "fiche1",
   },
 ];
@@ -83,7 +83,7 @@ const expected = [
   {
     document: {
       id: "fiche-sp-1",
-      source: "fiches_ministere_travail",
+      source: "page_fiche_ministere_travail",
       title: "fiche1#sous-titre",
     },
     references: [
@@ -106,7 +106,7 @@ const expected = [
   {
     document: {
       id: "fiche-sp-1",
-      source: "fiches_ministere_travail",
+      source: "page_fiche_ministere_travail",
       title: "fiche1#sous-titre-2",
     },
     references: [

--- a/targets/alert-cli/src/diff/dila/extractReferences/__tests__/ficheTravailEmploi.test.ts
+++ b/targets/alert-cli/src/diff/dila/extractReferences/__tests__/ficheTravailEmploi.test.ts
@@ -74,7 +74,7 @@ const mockFiches: FicheTravail[] = [
       url: "https://travail-emploi",
     },
     initialId: "fiche-sp-1",
-    source: "page_fiche_ministere_travail",
+    source: "fiches_ministere_travail",
     title: "fiche1",
   },
 ];
@@ -83,7 +83,7 @@ const expected = [
   {
     document: {
       id: "fiche-sp-1",
-      source: "page_fiche_ministere_travail",
+      source: "fiches_ministere_travail",
       title: "fiche1#sous-titre",
     },
     references: [
@@ -106,7 +106,7 @@ const expected = [
   {
     document: {
       id: "fiche-sp-1",
-      source: "page_fiche_ministere_travail",
+      source: "fiches_ministere_travail",
       title: "fiche1#sous-titre-2",
     },
     references: [

--- a/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
+++ b/targets/export-elasticsearch/src/ingester/cdtnDocuments.ts
@@ -192,6 +192,7 @@ export async function cdtnDocumentsGen(
         references: section.references,
         title: section.title,
       })),
+      source: SOURCES.SHEET_MT_PAGE,
     })
   );
   logger.info(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5681,6 +5681,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@socialgouv/cdtn-types@workspace:shared/types"
   dependencies:
+    "@socialgouv/cdtn-utils": ^4.156.1
     "@socialgouv/kali-data-types": ^2.127.0
     "@socialgouv/legi-data-types": ^2.73.1
     typescript: ^5.4.3
@@ -5713,6 +5714,13 @@ __metadata:
   version: 4.121.1
   resolution: "@socialgouv/cdtn-utils@npm:4.121.1"
   checksum: bad99ad3eab8d8e5c9737a39e634ffc370f30ef1bb0b01ead5192cbcef05e3b2f83c6c632b81e8e44440a0893c7f47f4ab1ef1e0dc820011224364e9c968b340
+  languageName: node
+  linkType: hard
+
+"@socialgouv/cdtn-utils@npm:^4.156.1":
+  version: 4.156.1
+  resolution: "@socialgouv/cdtn-utils@npm:4.156.1"
+  checksum: 3429e6f801e7bc748a7fc666972fee2855627fab13a32fe902f6f39cb9aff332248cf83a8cd061b6e303f75a9e5bdffcfe8c91681fbd8da7770e759a41a405f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Linked to https://github.com/SocialGouv/code-du-travail-numerique/issues/6196