### PR TITLE
feat(contribution): ajout des contributions conventionnelles dans la liste des documents

### DIFF
--- a/targets/frontend/src/components/documents/Container.js
+++ b/targets/frontend/src/components/documents/Container.js
@@ -129,37 +129,27 @@ DocumentListContainer.propTypes = {
 const searchDocumentQuery = `
 query documents($source: String, $search: String!, $published: [Boolean!]!, $available: [Boolean!]!, $offset: Int = 0, $limit: Int = 50) {
   documents(where: {
-    _or: [
-        { source: { _neq: "contributions" } }
-        { source: { _eq: "contributions" }, document: { _contains: { idcc: "0000" } } }
-    ]
-    _and: {
       source: {_eq: $source, _neq: "code_du_travail"}
       title: {_ilike: $search}
       is_published: {_in: $published}
       is_available: {_in: $available}
-    }
   },
   offset: $offset, limit: $limit, order_by: [{source: asc}, {slug: asc}]) {
     id: initial_id
     cdtnId: cdtn_id
     title
     source
+    idcc: document(path: "$idcc")
+    questionIndex: document(path: "$questionIndex")
     isPublished: is_published
     isAvailable: is_available
   }
 
   documents_aggregate(where: {
-    _or: [
-        { source: { _neq: "contributions" } }
-        { source: { _eq: "contributions" }, document: { _contains: { idcc: "0000" } } }
-    ]
-    _and: {
       source: {_eq: $source, _neq: "code_du_travail"}
       title: {_ilike: $search},
       is_published: {_in: $published}
       is_available: {_in: $available}
-    }
   }) {
     aggregate {
       count

--- a/targets/frontend/src/components/documents/List.js
+++ b/targets/frontend/src/components/documents/List.js
@@ -45,7 +45,16 @@ DocumentList.propTypes = {
 };
 
 const DocumentRow = function DocumentRow({
-  document: { cdtnId, id, source, title, isPublished, isAvailable },
+  document: {
+    cdtnId,
+    id,
+    source,
+    title,
+    idcc,
+    questionIndex,
+    isPublished,
+    isAvailable,
+  },
 }) {
   const [selectedItems, setSelectedItems] = useSelectionContext();
   const updatePublishedRef = () => {
@@ -93,7 +102,15 @@ const DocumentRow = function DocumentRow({
               textDecoration: isAvailable ? "none" : " line-through",
             }}
           >
-            {source} › {title}
+            {source === SOURCES.CONTRIBUTIONS ? (
+              <>
+                {source} › {questionIndex} - {title} (IDCC {idcc})
+              </>
+            ) : (
+              <>
+                {source} › {title}
+              </>
+            )}
           </span>
         </Link>
       </TableCell>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0209428e-79c6-42e2-a95b-7028756ddcc0)

Par contre, la recherche n'est pas optimale et ça devient compliqué de l'optimiser car l'idcc et le numéro de la question sont dans le document qui est un json.