### PR TITLE
fix(alert): gestion du cas où une section peut avoir un titre vide

### DIFF
--- a/targets/alert-cli/src/diff/dila/CompareDilaContent.ts
+++ b/targets/alert-cli/src/diff/dila/CompareDilaContent.ts
@@ -277,9 +277,7 @@ const getParents = (node: WithParent<DilaNode> | null) => {
     if (isSectionData(tempNode.data)) {
       chain.unshift(tempNode.data.title);
     } else {
-      throw new Error(
-        "An article cannot be a parent of an article or a section"
-      );
+      // Skip it, sometimes a section can have no title (example : https://www.legifrance.gouv.fr/conv_coll/article/KALIARTI000005778323?idConteneur=KALICONT000005635221)
     }
     tempNode = tempNode.parent;
   }


### PR DESCRIPTION
(https://www.legifrance.gouv.fr/conv_coll/article/KALIARTI000005778323?idConteneur=KALICONT000005635221)

<img width="2524" height="2074" alt="CleanShot 2026-04-29 at 20 51 57@2x" src="https://github.com/user-attachments/assets/55063be7-f88f-455a-ac98-994eb8ee6a04" />
