### PR TITLE
ci: migrate image builds from buildkit-service to buildkit-operator

### DIFF
--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -12,6 +12,9 @@ concurrency:
 
 jobs:
   build-frontend:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -29,21 +32,25 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for frontend
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for frontend
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/frontend/Dockerfile"
+          file: "targets/frontend/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           build-args: |
             NEXT_PUBLIC_BASE_PATH=https://cdtn-admin-preprod.ovh.fabrique.social.gouv.fr
             NEXT_PUBLIC_BUCKET_PUBLIC_ENDPOINT=https://cdtn-dev-public.s3.gra.io.cloud.ovh.net
@@ -51,8 +58,12 @@ jobs:
             NEXT_PUBLIC_BUCKET_DRAFT_FOLDER=draft
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
+          push: true
 
   build-ingester:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -70,23 +81,31 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for ingester
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for ingester
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/ingester/Dockerfile"
+          file: "targets/ingester/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-alert:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -104,23 +123,31 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for alert
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for alert
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/alert-cli/Dockerfile"
+          file: "targets/alert-cli/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-export:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -138,25 +165,33 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for export
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for export
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/export-elasticsearch/Dockerfile"
+          file: "targets/export-elasticsearch/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
+          push: true
 
   build-hasura:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -174,21 +209,25 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for hasura
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for hasura
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "targets/hasura"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   kontinuous:
     needs:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -23,6 +23,9 @@ jobs:
             Un déploiement en production du site d'administration est en cours de préparation, **veuillez ne pas lancer de mise à jour des données** ([logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})) ⏳
 
   build-frontend:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -41,21 +44,25 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for frontend
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for frontend
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/frontend/Dockerfile"
+          file: "targets/frontend/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
           build-args: |
@@ -63,8 +70,12 @@ jobs:
             NEXT_PUBLIC_BUCKET_PUBLIC_ENDPOINT=https://cdtn-prod-public.s3.gra.io.cloud.ovh.net
             NEXT_PUBLIC_BUCKET_DEFAULT_FOLDER=default
             NEXT_PUBLIC_BUCKET_DRAFT_FOLDER=draft
+          push: true
 
   build-ingester:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -83,23 +94,31 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for ingester
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for ingester
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/ingester/Dockerfile"
+          file: "targets/ingester/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-alert:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -118,23 +137,31 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for alert
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for alert
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/alert-cli/Dockerfile"
+          file: "targets/alert-cli/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-export:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -153,25 +180,33 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for export
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for export
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/export-elasticsearch/Dockerfile"
+          file: "targets/export-elasticsearch/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
+          push: true
 
   build-hasura:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -190,21 +225,25 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for hasura
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for hasura
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "targets/hasura"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   kontinuous:
     needs:

--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   build-frontend:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -42,21 +45,25 @@ jobs:
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
 
-      - name: 📦 Build and push Docker image for frontend
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for frontend
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/frontend/Dockerfile"
+          file: "targets/frontend/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           build-args: |
             NEXT_PUBLIC_BASE_PATH=https://www-${{ steps.env.outputs.subdomain }}.ovh.fabrique.social.gouv.fr
             NEXT_PUBLIC_BUCKET_PUBLIC_ENDPOINT=https://cdtn-dev-public.s3.gra.io.cloud.ovh.net
@@ -64,8 +71,12 @@ jobs:
             NEXT_PUBLIC_BUCKET_DRAFT_FOLDER=draft
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
+          push: true
 
   build-ingester:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -90,23 +101,31 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for ingester
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for ingester
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/ingester/Dockerfile"
+          file: "targets/ingester/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-alert:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -131,23 +150,31 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for alert
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for alert
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/alert-cli/Dockerfile"
+          file: "targets/alert-cli/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-export:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -172,25 +199,33 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for export
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for export
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/export-elasticsearch/Dockerfile"
+          file: "targets/export-elasticsearch/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
+          push: true
 
   build-hasura:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -215,21 +250,25 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for hasura
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for hasura
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "targets/hasura"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   kontinuous:
     needs:

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -11,6 +11,9 @@ concurrency:
 
 jobs:
   build-frontend:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -39,21 +42,25 @@ jobs:
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
 
-      - name: 📦 Build and push Docker image for frontend
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for frontend
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/frontend/Dockerfile"
+          file: "targets/frontend/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           build-args: |
             NEXT_PUBLIC_BASE_PATH=https://www-${{ steps.env.outputs.subdomain }}.ovh.fabrique.social.gouv.fr
             NEXT_PUBLIC_BUCKET_PUBLIC_ENDPOINT=https://cdtn-dev-public.s3.gra.io.cloud.ovh.net
@@ -61,8 +68,12 @@ jobs:
             NEXT_PUBLIC_BUCKET_DRAFT_FOLDER=draft
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
+          push: true
 
   build-ingester:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -87,23 +98,31 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for ingester
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for ingester
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/ingester/Dockerfile"
+          file: "targets/ingester/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-alert:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -128,23 +147,31 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for alert
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for alert
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/alert-cli/Dockerfile"
+          file: "targets/alert-cli/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-export:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -169,25 +196,33 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for export
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for export
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "targets/export-elasticsearch/Dockerfile"
+          file: "targets/export-elasticsearch/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           secrets: |
             NPM_TIPTAP_TOKEN=${{ secrets.NPM_TIPTAP_TOKEN }}
+          push: true
 
   build-hasura:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -212,21 +247,25 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for hasura
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for hasura
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "targets/hasura"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   kontinuous:
     needs:


### PR DESCRIPTION
Migre les builds d'images CI du service legacy **buildkit-service** (`socialgouv/workflows/actions/buildkit@v1`, `buildctl` sur le runner) vers **[buildkit-operator](https://github.com/SocialGouv/buildkit-operator)** (`socialgouv/buildkit-operator@v1`) : chaque build est routé vers le buildkitd chaud dédié au repo (cache par projet, plus de consistent-hash sur 6 daemons partagés).

**12 repos SocialGouv déjà migrés et en production sur ce modèle** (revu, da-manager, jardinmental, enfants-du-spectacle, famille 1000jours…) — builds et deploys validés de bout en bout.

## Mapping

- `socialgouv/workflows/actions/buildkit@v1` → `socialgouv/buildkit-operator@v1` (`dockerfile:` → `file:`, `push: true` explicite ; `build-args`, `secrets`, `target` inchangés).
- Auth `/route` : GitHub OIDC (`permissions.id-token: write` sur le job de build) — identité du repo vérifiée côté serveur, aucun token partagé.
- Secrets/vars org-level (`BUILDKIT_OPERATOR_CA/CERT/KEY`, `BUILDKIT_OPERATOR_BUILDD_URL`, `BUILDKIT_OPERATOR_GATEWAY_HOST`) → zéro setup côté repo.
- Login registry : `docker/login-action@v4` (auth forwardée au daemon via la session buildx) — remplace les inputs `registry*` de l'action legacy.
- Supprimés (sans objet) : `buildkit-daemon-address`, `buildkit-svc-count`, `buildkit-cert-*`, `cache-*` (le cache vit dans le daemon du projet), `fallback-enabled`.

## Validation & merge

Le build a été validé sur cette branche (voir checks/runs). **Le merge revient à l'équipe** — buildkit-service reste en service pendant toute la migration, le rollback est un simple revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
